### PR TITLE
Change logbook entries for level ups

### DIFF
--- a/data/apoxys/level100.txt
+++ b/data/apoxys/level100.txt
@@ -587,6 +587,8 @@ mission "Apoxys Level 100 Choices"
 				"mark v choices" == 0
 
 			label special
+			action
+				log Levels "Apoxys" "Level 100: Re-chose upgrades."
 			`"Okay, captain, we've got one more choice to make: Cloaking Field, or Spinal Mount?" Maribelle asks.`
 			choice
 				`	"Go for the Cloaking Field."`
@@ -597,7 +599,7 @@ mission "Apoxys Level 100 Choices"
 			label cloak
 			action
 				outfit "Perk: Cloaking Field" 1
-				log Levels "Level 100" "Chose Cloaking Field."
+				log Levels "Apoxys" "	Chose Cloaking Field."
 			`Maribelle looks at you. "Are you sure?" She asks.`
 			`	"Yes," You reply. "I'm certain."`
 			`	Maribelle nods. "Consider it done, then, captain."`
@@ -606,7 +608,7 @@ mission "Apoxys Level 100 Choices"
 			label spinal
 			action
 				outfit "Perk: Spinal Mount" 1
-				log Levels "Level 100" "Chose Spinal Mount."
+				log Levels "Apoxys" "	Chose Spinal Mount."
 			`Maribelle looks at you. "Are you sure?" She asks.`
 			`	"Yes," You reply. "I'm certain."`
 			`	Maribelle nods. "Consider it done, then, captain."`

--- a/data/apoxys/levels1-20.txt
+++ b/data/apoxys/levels1-20.txt
@@ -153,56 +153,56 @@ mission "Apoxys Level 1"
 			action
 				outfit "Shields I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 1" "Chose shield upgrade."
+				log Levels "Apoxys" "	Level 1: Chose shield upgrade."
 			`"Oh!" Maribelle replies, seemingly a bit surprised that you cared to give your own input, "I'll do just that, then Captain. Only the strongest shields to keep the bad things out!"`
 				decline
 			label hullcap
 			action
 				outfit "Hull I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 1" "Chose hull upgrade."
+				log Levels "Apoxys" "	Level 1: Chose hull upgrade."
 			`"Oh!" Maribelle replies, seemingly a bit surprised that you cared to give your own input, "I'll do just that, then Captain. The most durable hull, for resisting all that space throws at us!"`
 				decline
 			label outfitcap
 			action
 				outfit "Outfit I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 1" "Chose outfit upgrade."
+				log Levels "Apoxys" "	Level 1: Chose outfit upgrade."
 			`"Oh!" Maribelle replies, seemingly a bit surprised that you cared to give your own input, "I'll do just that, then Captain. Just imagine what we can do with all the extra space!"`
 				decline
 			label heatcap
 			action
 				outfit "Heat Capacity I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 1" "Chose heat capacity upgrade."
+				log Levels "Apoxys" "	Level 1: Chose heat capacity upgrade."
 			`"Oh!" Maribelle replies, seemingly a bit surprised that you cared to give your own input, "I'll do just that, then Captain. No heat will be too mighty for our heatsinks!"`
 				decline
 			label weaponcap
 			action
 				outfit "Weapons I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 1" "Chose weapon upgrade."
+				log Levels "Apoxys" "	Level 1: Chose weapon upgrade."
 			`"Oh!" Maribelle replies, seemingly a bit surprised that you cared to give your own input, "I'll do just that, then Captain. Our projectiles will blot out the sun! Maybe even a couple suns."`
 				decline
 			label enginecap
 			action
 				outfit "Engines I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 1" "Chose engine upgrade."
+				log Levels "Apoxys" "	Level 1: Chose engine upgrade."
 			`"Oh!" Maribelle replies, seemingly a bit surprised that you cared to give your own input, "I'll do just that, then Captain. Our engines will move us like a moth to a flame! Ideally without the burning alive part."`
 				decline
 			label cargocap
 			action
 				outfit "Cargo I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 1" "Chose cargo upgrade."
+				log Levels "Apoxys" "	Level 1: Chose cargo upgrade."
 			`"Oh!" Maribelle replies, seemingly a bit surprised that you cared to give your own input, "I'll do just that, then Captain. We'll be able to carry plenty of goodies now!"`
 				decline
 			label bunkcap
 			action
 				outfit "Bunks I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 1" "Chose bunk upgrade."
+				log Levels "Apoxys" "	Level 1: Chose bunk upgrade."
 			`"Oh!" Maribelle replies, seemingly a bit surprised that you cared to give your own input, "I'll do just that, then Captain. We'll have room for all sorts of friends!"`
 				decline
 
@@ -243,56 +243,56 @@ mission "Apoxys Level 2"
 			action
 				outfit "Shields I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 2" "Chose shield upgrade."
+				log Levels "Apoxys" "Level 2: Chose shield upgrade."
 			`"I'll be sure it's done, captain," Maribelle replies.`
 				goto next
 			label hullcap
 			action
 				outfit "Hull I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 2" "Chose hull upgrade."
+				log Levels "Apoxys" "Level 2: Chose hull upgrade."
 			`"I'll be sure it's done, captain," Maribelle replies.`
 				goto next
 			label outfitcap
 			action
 				outfit "Outfit I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 2" "Chose outfit upgrade."
+				log Levels "Apoxys" "Level 2: Chose outfit upgrade."
 			`"I'll be sure it's done, captain," Maribelle replies.`
 				goto next
 			label heatcap
 			action
 				outfit "Heat Capacity I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 2" "Chose heat capacity upgrade."
+				log Levels "Apoxys" "Level 2: Chose heat capacity upgrade."
 			`"I'll be sure it's done, captain," Maribelle replies.`
 				goto next
 			label weaponcap
 			action
 				outfit "Weapons I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 2" "Chose weapon upgrade."
+				log Levels "Apoxys" "Level 2: Chose weapon upgrade."
 			`"I'll be sure it's done, captain," Maribelle replies.`
 				goto next
 			label enginecap
 			action
 				outfit "Engines I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 2" "Chose engine upgrade."
+				log Levels "Apoxys" "Level 2: Chose engine upgrade."
 			`"I'll be sure it's done, captain," Maribelle replies.`
 				goto next
 			label cargocap
 			action
 				outfit "Cargo I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 2" "Chose cargo upgrade."
+				log Levels "Apoxys" "Level 2: Chose cargo upgrade."
 			`"I'll be sure it's done, captain," Maribelle replies.`
 				goto next
 			label bunkcap
 			action
 				outfit "Bunks I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 2" "Chose bunk upgrade."
+				log Levels "Apoxys" "Level 2: Chose bunk upgrade."
 			`"I'll be sure it's done, captain," Maribelle replies.`
 				goto next
 
@@ -340,56 +340,56 @@ mission "Apoxys Level 3"
 			action
 				outfit "Shields I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 3" "Chose shield upgrade."
+				log Levels "Apoxys" "Level 3: Chose shield upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Only the strongest shields to keep the bad things out!"`
 				decline
 			label hullcap
 			action
 				outfit "Hull I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 3" "Chose hull upgrade."
+				log Levels "Apoxys" "Level 3: Chose hull upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. The most durable hull, for resisting all that space throws at us!"`
 				decline
 			label outfitcap
 			action
 				outfit "Outfit I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 3" "Chose outfit upgrade."
+				log Levels "Apoxys" "Level 3: Chose outfit upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Just imagine what we can do with all the extra space!"`
 				decline
 			label heatcap
 			action
 				outfit "Heat Capacity I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 3" "Chose heat capacity upgrade."
+				log Levels "Apoxys" "Level 3: Chose heat capacity upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Heat shouldn't be nearly as much of an issue, now!"`
 				decline
 			label weaponcap
 			action
 				outfit "Weapons I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 3" "Chose weapon upgrade."
+				log Levels "Apoxys" "Level 3: Chose weapon upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Our projectiles will blot out the sun! Maybe even a couple suns."`
 				decline
 			label enginecap
 			action
 				outfit "Engines I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 3" "Chose engine upgrade."
+				log Levels "Apoxys" "Level 3: Chose engine upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Our engines will move us like a moth to a flame! Ideally without the burning alive part."`
 				decline
 			label cargocap
 			action
 				outfit "Cargo I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 3" "Chose cargo upgrade."
+				log Levels "Apoxys" "Level 3: Chose cargo upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. We'll be able to carry plenty of goodies now!"`
 				decline
 			label bunkcap
 			action
 				outfit "Bunks I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 3" "Chose bunk upgrade."
+				log Levels "Apoxys" "Level 3: Chose bunk upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. We'll have room for all sorts of friends!"`
 				decline
 
@@ -431,56 +431,56 @@ mission "Apoxys Level 4"
 			action
 				outfit "Shields I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 4" "Chose shield upgrade."
+				log Levels "Apoxys" "Level 4: Chose shield upgrade."
 			`"More shields sound good, captain!" Maribelle replies giddily.`
 				goto next
 			label hullcap
 			action
 				outfit "Hull I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 4" "Chose hull upgrade."
+				log Levels "Apoxys" "Level 4: Chose hull upgrade."
 			`"More hull sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label outfitcap
 			action
 				outfit "Outfit I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 4" "Chose outfit upgrade."
+				log Levels "Apoxys" "Level 4: Chose outfit upgrade."
 			`"More space sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label heatcap
 			action
 				outfit "Heat Capacity I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 4" "Chose heat capacity upgrade."
+				log Levels "Apoxys" "Level 4: Chose heat capacity upgrade."
 			`"More heat capacity sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label weaponcap
 			action
 				outfit "Weapons I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 4" "Chose weapon upgrade."
+				log Levels "Apoxys" "Level 4: Chose weapon upgrade."
 			`"More weaponry sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label enginecap
 			action
 				outfit "Engines I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 4" "Chose engine upgrade."
+				log Levels "Apoxys" "Level 4: Chose engine upgrade."
 			`"More engine capabilities sound good, captain!" Maribelle replies giddily.`
 				goto next
 			label cargocap
 			action
 				outfit "Cargo I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 4" "Chose cargo upgrade."
+				log Levels "Apoxys" "Level 4: Chose cargo upgrade."
 			`"More carrying capacity sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label bunkcap
 			action
 				outfit "Bunks I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 4" "Chose bunk upgrade."
+				log Levels "Apoxys" "Level 4: Chose bunk upgrade."
 			`"I'll be sure it's done, captain," Maribelle replies.`
 				goto next
 
@@ -527,56 +527,56 @@ mission "Apoxys Level 5"
 			action
 				outfit "Shields I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 5" "Chose shield upgrade."
+				log Levels "Apoxys" "Level 5: Chose shield upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Only the strongest shields to keep the bad things out!"`
 				decline
 			label hullcap
 			action
 				outfit "Hull I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 5" "Chose hull upgrade."
+				log Levels "Apoxys" "Level 5: Chose hull upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. The most durable hull, for resisting all that space throws at us!"`
 				decline
 			label outfitcap
 			action
 				outfit "Outfit I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 5" "Chose outfit upgrade."
+				log Levels "Apoxys" "Level 5: Chose outfit upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Just imagine what we can do with all the extra space!"`
 				decline
 			label heatcap
 			action
 				outfit "Heat Capacity I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 5" "Chose heat capacity upgrade."
+				log Levels "Apoxys" "Level 5: Chose heat capacity upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Heat shouldn't be nearly as much of an issue, now!"`
 				decline
 			label weaponcap
 			action
 				outfit "Weapons I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 5" "Chose weapon upgrade."
+				log Levels "Apoxys" "Level 5: Chose weapon upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Our projectiles will blot out the sun! Maybe even a couple suns."`
 				decline
 			label enginecap
 			action
 				outfit "Engines I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 5" "Chose engine upgrade."
+				log Levels "Apoxys" "Level 5: Chose engine upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Our engines will move us like a moth to a flame! Ideally without the burning alive part."`
 				decline
 			label cargocap
 			action
 				outfit "Cargo I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 5" "Chose cargo upgrade."
+				log Levels "Apoxys" "Level 5: Chose cargo upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. We'll be able to carry plenty of goodies now!"`
 				decline
 			label bunkcap
 			action
 				outfit "Bunks I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 5" "Chose bunk upgrade."
+				log Levels "Apoxys" "Level 5: Chose bunk upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. We'll have room for all sorts of friends!"`
 				decline
 
@@ -618,56 +618,56 @@ mission "Apoxys Level 6"
 			action
 				outfit "Shields I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 6" "Chose shield upgrade."
+				log Levels "Apoxys" "Level 6: Chose shield upgrade."
 			`"More shields sound good, captain!" Maribelle replies giddily.`
 				goto next
 			label hullcap
 			action
 				outfit "Hull I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 6" "Chose hull upgrade."
+				log Levels "Apoxys" "Level 6: Chose hull upgrade."
 			`"More hull sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label outfitcap
 			action
 				outfit "Outfit I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 6" "Chose outfit upgrade."
+				log Levels "Apoxys" "Level 6: Chose outfit upgrade."
 			`"More space sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label heatcap
 			action
 				outfit "Heat Capacity I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 6" "Chose heat capacity upgrade."
+				log Levels "Apoxys" "Level 6: Chose heat capacity upgrade."
 			`"More heat capacity sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label weaponcap
 			action
 				outfit "Weapons I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 6" "Chose weapon upgrade."
+				log Levels "Apoxys" "Level 6: Chose weapon upgrade."
 			`"More weaponry sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label enginecap
 			action
 				outfit "Engines I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 6" "Chose engine upgrade."
+				log Levels "Apoxys" "Level 6: Chose engine upgrade."
 			`"More engine capabilities sound good, captain!" Maribelle replies giddily.`
 				goto next
 			label cargocap
 			action
 				outfit "Cargo I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 6" "Chose cargo upgrade."
+				log Levels "Apoxys" "Level 6: Chose cargo upgrade."
 			`"More carrying capacity sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label bunkcap
 			action
 				outfit "Bunks I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 6" "Chose bunk upgrade."
+				log Levels "Apoxys" "Level 6: Chose bunk upgrade."
 			`"I'll be sure it's done, captain," Maribelle replies.`
 				goto next
 
@@ -714,56 +714,56 @@ mission "Apoxys Level 7"
 			action
 				outfit "Shields I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 7" "Chose shield upgrade."
+				log Levels "Apoxys" "Level 7: Chose shield upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Only the strongest shields to keep the bad things out!"`
 				decline
 			label hullcap
 			action
 				outfit "Hull I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 7" "Chose hull upgrade."
+				log Levels "Apoxys" "Level 7: Chose hull upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. The most durable hull, for resisting all that space throws at us!"`
 				decline
 			label outfitcap
 			action
 				outfit "Outfit I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 7" "Chose outfit upgrade."
+				log Levels "Apoxys" "Level 7: Chose outfit upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Just imagine what we can do with all the extra space!"`
 				decline
 			label heatcap
 			action
 				outfit "Heat Capacity I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 7" "Chose heat capacity upgrade."
+				log Levels "Apoxys" "Level 7: Chose heat capacity upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Heat shouldn't be nearly as much of an issue, now!"`
 				decline
 			label weaponcap
 			action
 				outfit "Weapons I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 7" "Chose weapon upgrade."
+				log Levels "Apoxys" "Level 7: Chose weapon upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Our projectiles will blot out the sun! Maybe even a couple suns."`
 				decline
 			label enginecap
 			action
 				outfit "Engines I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 7" "Chose engine upgrade."
+				log Levels "Apoxys" "Level 7: Chose engine upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Our engines will move us like a moth to a flame! Ideally without the burning alive part."`
 				decline
 			label cargocap
 			action
 				outfit "Cargo I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 7" "Chose cargo upgrade."
+				log Levels "Apoxys" "Level 7: Chose cargo upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. We'll be able to carry plenty of goodies now!"`
 				decline
 			label bunkcap
 			action
 				outfit "Bunks I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 7" "Chose bunk upgrade."
+				log Levels "Apoxys" "Level 7: Chose bunk upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. We'll have room for all sorts of friends!"`
 				decline
 
@@ -805,56 +805,56 @@ mission "Apoxys Level 8"
 			action
 				outfit "Shields I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 8" "Chose shield upgrade."
+				log Levels "Apoxys" "Level 8: Chose shield upgrade."
 			`"More shields sound good, captain!" Maribelle replies giddily.`
 				goto next
 			label hullcap
 			action
 				outfit "Hull I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 8" "Chose hull upgrade."
+				log Levels "Apoxys" "Level 8: Chose hull upgrade."
 			`"More hull sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label outfitcap
 			action
 				outfit "Outfit I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 8" "Chose outfit upgrade."
+				log Levels "Apoxys" "Level 8: Chose outfit upgrade."
 			`"More space sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label heatcap
 			action
 				outfit "Heat Capacity I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 8" "Chose heat capacity upgrade."
+				log Levels "Apoxys" "Level 8: Chose heat capacity upgrade."
 			`"More heat capacity sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label weaponcap
 			action
 				outfit "Weapons I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 8" "Chose weapon upgrade."
+				log Levels "Apoxys" "Level 8: Chose weapon upgrade."
 			`"More weaponry sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label enginecap
 			action
 				outfit "Engines I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 8" "Chose engine upgrade."
+				log Levels "Apoxys" "Level 8: Chose engine upgrade."
 			`"More engine capabilities sound good, captain!" Maribelle replies giddily.`
 				goto next
 			label cargocap
 			action
 				outfit "Cargo I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 8" "Chose cargo upgrade."
+				log Levels "Apoxys" "Level 8: Chose cargo upgrade."
 			`"More carrying capacity sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label bunkcap
 			action
 				outfit "Bunks I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 8" "Chose bunk upgrade."
+				log Levels "Apoxys" "Level 8: Chose bunk upgrade."
 			`"I'll be sure it's done, captain," Maribelle replies.`
 				goto next
 
@@ -901,56 +901,56 @@ mission "Apoxys Level 9"
 			action
 				outfit "Shields I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 9" "Chose shield upgrade."
+				log Levels "Apoxys" "Level 9: Chose shield upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Only the strongest shields to keep the bad things out!"`
 				decline
 			label hullcap
 			action
 				outfit "Hull I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 9" "Chose hull upgrade."
+				log Levels "Apoxys" "Level 9: Chose hull upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. The most durable hull, for resisting all that space throws at us!"`
 				decline
 			label outfitcap
 			action
 				outfit "Outfit I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 9" "Chose outfit upgrade."
+				log Levels "Apoxys" "Level 9: Chose outfit upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Just imagine what we can do with all the extra space!"`
 				decline
 			label heatcap
 			action
 				outfit "Heat Capacity I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 9" "Chose heat capacity upgrade."
+				log Levels "Apoxys" "Level 9: Chose heat capacity upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Heat shouldn't be nearly as much of an issue, now!"`
 				decline
 			label weaponcap
 			action
 				outfit "Weapons I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 9" "Chose weapon upgrade."
+				log Levels "Apoxys" "Level 9: Chose weapon upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Our projectiles will blot out the sun! Maybe even a couple suns."`
 				decline
 			label enginecap
 			action
 				outfit "Engines I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 9" "Chose engine upgrade."
+				log Levels "Apoxys" "Level 9: Chose engine upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Our engines will move us like a moth to a flame! Ideally without the burning alive part."`
 				decline
 			label cargocap
 			action
 				outfit "Cargo I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 9" "Chose cargo upgrade."
+				log Levels "Apoxys" "Level 9: Chose cargo upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. We'll be able to carry plenty of goodies now!"`
 				decline
 			label bunkcap
 			action
 				outfit "Bunks I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 9" "Chose bunk upgrade."
+				log Levels "Apoxys" "Level 9: Chose bunk upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. We'll have room for all sorts of friends!"`
 				decline
 
@@ -993,56 +993,56 @@ mission "Apoxys Level 10"
 			action
 				outfit "Shields I" 1
 				outfit "Milestone I" 1
-				log Levels "Level 10" "Chose shield upgrade."
+				log Levels "Apoxys" "Level 10: Chose shield upgrade."
 			`"I'll be sure to delegate some energy to that!" Maribelle says, still shaking excitedly.`
 				goto next
 			label hullcap
 			action
 				outfit "Hull I" 1
 				outfit "Milestone I" 1
-				log Levels "Level 10" "Chose hull upgrade."
+				log Levels "Apoxys" "Level 10: Chose hull upgrade."
 			`"I'll be sure to delegate some energy to that!" Maribelle says, still shaking excitedly.`
 				goto next
 			label outfitcap
 			action
 				outfit "Outfit I" 1
 				outfit "Milestone I" 1
-				log Levels "Level 10" "Chose outfit upgrade."
+				log Levels "Apoxys" "Level 10: Chose outfit upgrade."
 			`"I'll be sure to delegate some energy to that!" Maribelle says, still shaking excitedly.`
 				goto next
 			label heatcap
 			action
 				outfit "Heat Capacity I" 1
 				outfit "Milestone I" 1
-				log Levels "Level 10" "Chose heat capacity upgrade."
+				log Levels "Apoxys" "Level 10: Chose heat capacity upgrade."
 			`"I'll be sure to delegate some energy to that!" Maribelle says, still shaking excitedly.`
 				goto next
 			label weaponcap
 			action
 				outfit "Weapons I" 1
 				outfit "Milestone I" 1
-				log Levels "Level 10" "Chose weapon upgrade."
+				log Levels "Apoxys" "Level 10: Chose weapon upgrade."
 			`"I'll be sure to delegate some energy to that!" Maribelle says, still shaking excitedly.`
 				goto next
 			label enginecap
 			action
 				outfit "Engines I" 1
 				outfit "Milestone I" 1
-				log Levels "Level 10" "Chose engine upgrade."
+				log Levels "Apoxys" "Level 10: Chose engine upgrade."
 			`"I'll be sure to delegate some energy to that!" Maribelle says, still shaking excitedly.`
 				goto next
 			label cargocap
 			action
 				outfit "Cargo I" 1
 				outfit "Milestone I" 1
-				log Levels "Level 10" "Chose cargo upgrade."
+				log Levels "Apoxys" "Level 10: Chose cargo upgrade."
 			`"I'll be sure to delegate some energy to that!" Maribelle says, still shaking excitedly.`
 				goto next
 			label bunkcap
 			action
 				outfit "Bunks I" 1
 				outfit "Milestone I" 1
-				log Levels "Level 10" "Chose bunk upgrade."
+				log Levels "Apoxys" "Level 10: Chose bunk upgrade."
 			`"I'll be sure to delegate some energy to that!" Maribelle says, still shaking excitedly.`
 				goto next
 
@@ -1089,56 +1089,56 @@ mission "Apoxys Level 11"
 			action
 				outfit "Shields I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 11" "Chose shield upgrade."
+				log Levels "Apoxys" "Level 11: Chose shield upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Only the strongest shields to keep the bad things out!"`
 				decline
 			label hullcap
 			action
 				outfit "Hull I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 11" "Chose hull upgrade."
+				log Levels "Apoxys" "Level 11: Chose hull upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. The most durable hull, for resisting all that space throws at us!"`
 				decline
 			label outfitcap
 			action
 				outfit "Outfit I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 11" "Chose outfit upgrade."
+				log Levels "Apoxys" "Level 11: Chose outfit upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Just imagine what we can do with all the extra space!"`
 				decline
 			label heatcap
 			action
 				outfit "Heat Capacity I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 11" "Chose heat capacity upgrade."
+				log Levels "Apoxys" "Level 11: Chose heat capacity upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Heat shouldn't be nearly as much of an issue, now!"`
 				decline
 			label weaponcap
 			action
 				outfit "Weapons I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 11" "Chose weapon upgrade."
+				log Levels "Apoxys" "Level 11: Chose weapon upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Our projectiles will blot out the sun! Maybe even a couple suns."`
 				decline
 			label enginecap
 			action
 				outfit "Engines I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 11" "Chose engine upgrade."
+				log Levels "Apoxys" "Level 11: Chose engine upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Our engines will move us like a moth to a flame! Ideally without the burning alive part."`
 				decline
 			label cargocap
 			action
 				outfit "Cargo I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 11" "Chose cargo upgrade."
+				log Levels "Apoxys" "Level 11: Chose cargo upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. We'll be able to carry plenty of goodies now!"`
 				decline
 			label bunkcap
 			action
 				outfit "Bunks I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 11" "Chose bunk upgrade."
+				log Levels "Apoxys" "Level 11: Chose bunk upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. We'll have room for all sorts of friends!"`
 				decline
 
@@ -1180,56 +1180,56 @@ mission "Apoxys Level 12"
 			action
 				outfit "Shields I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 12" "Chose shield upgrade."
+				log Levels "Apoxys" "Level 12: Chose shield upgrade."
 			`"I'll be sure it's done, captain," Maribelle replies.`
 				goto next
 			label hullcap
 			action
 				outfit "Hull I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 12" "Chose hull upgrade."
+				log Levels "Apoxys" "Level 12: Chose hull upgrade."
 			`"I'll be sure it's done, captain," Maribelle replies.`
 				goto next
 			label outfitcap
 			action
 				outfit "Outfit I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 12" "Chose outfit upgrade."
+				log Levels "Apoxys" "Level 12: Chose outfit upgrade."
 			`"I'll be sure it's done, captain," Maribelle replies.`
 				goto next
 			label heatcap
 			action
 				outfit "Heat Capacity I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 12" "Chose heat capacity upgrade."
+				log Levels "Apoxys" "Level 12: Chose heat capacity upgrade."
 			`"I'll be sure it's done, captain," Maribelle replies.`
 				goto next
 			label weaponcap
 			action
 				outfit "Weapons I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 12" "Chose weapon upgrade."
+				log Levels "Apoxys" "Level 12: Chose weapon upgrade."
 			`"I'll be sure it's done, captain," Maribelle replies.`
 				goto next
 			label enginecap
 			action
 				outfit "Engines I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 12" "Chose engine upgrade."
+				log Levels "Apoxys" "Level 12: Chose engine upgrade."
 			`"I'll be sure it's done, captain," Maribelle replies.`
 				goto next
 			label cargocap
 			action
 				outfit "Cargo I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 12" "Chose cargo upgrade."
+				log Levels "Apoxys" "Level 12: Chose cargo upgrade."
 			`"I'll be sure it's done, captain," Maribelle replies.`
 				goto next
 			label bunkcap
 			action
 				outfit "Bunks I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 12" "Chose bunk upgrade."
+				log Levels "Apoxys" "Level 12: Chose bunk upgrade."
 			`"I'll be sure it's done, captain," Maribelle replies.`
 				goto next
 
@@ -1277,56 +1277,56 @@ mission "Apoxys Level 13"
 			action
 				outfit "Shields I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 13" "Chose shield upgrade."
+				log Levels "Apoxys" "Level 13: Chose shield upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Only the strongest shields to keep the bad things out!"`
 				decline
 			label hullcap
 			action
 				outfit "Hull I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 13" "Chose hull upgrade."
+				log Levels "Apoxys" "Level 13: Chose hull upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. The most durable hull, for resisting all that space throws at us!"`
 				decline
 			label outfitcap
 			action
 				outfit "Outfit I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 13" "Chose outfit upgrade."
+				log Levels "Apoxys" "Level 13: Chose outfit upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Just imagine what we can do with all the extra space!"`
 				decline
 			label heatcap
 			action
 				outfit "Heat Capacity I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 13" "Chose heat capacity upgrade."
+				log Levels "Apoxys" "Level 13: Chose heat capacity upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Heat shouldn't be nearly as much of an issue, now!"`
 				decline
 			label weaponcap
 			action
 				outfit "Weapons I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 13" "Chose weapon upgrade."
+				log Levels "Apoxys" "Level 13: Chose weapon upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Our projectiles will blot out the sun! Maybe even a couple suns."`
 				decline
 			label enginecap
 			action
 				outfit "Engines I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 13" "Chose engine upgrade."
+				log Levels "Apoxys" "Level 13: Chose engine upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Our engines will move us like a moth to a flame! Ideally without the burning alive part."`
 				decline
 			label cargocap
 			action
 				outfit "Cargo I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 13" "Chose cargo upgrade."
+				log Levels "Apoxys" "Level 13: Chose cargo upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. We'll be able to carry plenty of goodies now!"`
 				decline
 			label bunkcap
 			action
 				outfit "Bunks I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 13" "Chose bunk upgrade."
+				log Levels "Apoxys" "Level 13: Chose bunk upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. We'll have room for all sorts of friends!"`
 				decline
 
@@ -1368,56 +1368,56 @@ mission "Apoxys Level 14"
 			action
 				outfit "Shields I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 14" "Chose shield upgrade."
+				log Levels "Apoxys" "Level 14: Chose shield upgrade."
 			`"More shields sound good, captain!" Maribelle replies giddily.`
 				goto next
 			label hullcap
 			action
 				outfit "Hull I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 14" "Chose hull upgrade."
+				log Levels "Apoxys" "Level 14: Chose hull upgrade."
 			`"More hull sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label outfitcap
 			action
 				outfit "Outfit I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 14" "Chose outfit upgrade."
+				log Levels "Apoxys" "Level 14: Chose outfit upgrade."
 			`"More space sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label heatcap
 			action
 				outfit "Heat Capacity I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 14" "Chose heat capacity upgrade."
+				log Levels "Apoxys" "Level 14: Chose heat capacity upgrade."
 			`"More heat capacity sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label weaponcap
 			action
 				outfit "Weapons I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 14" "Chose weapon upgrade."
+				log Levels "Apoxys" "Level 14: Chose weapon upgrade."
 			`"More weaponry sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label enginecap
 			action
 				outfit "Engines I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 14" "Chose engine upgrade."
+				log Levels "Apoxys" "Level 14: Chose engine upgrade."
 			`"More engine capabilities sound good, captain!" Maribelle replies giddily.`
 				goto next
 			label cargocap
 			action
 				outfit "Cargo I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 14" "Chose cargo upgrade."
+				log Levels "Apoxys" "Level 14: Chose cargo upgrade."
 			`"More carrying capacity sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label bunkcap
 			action
 				outfit "Bunks I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 14" "Chose bunk upgrade."
+				log Levels "Apoxys" "Level 14: Chose bunk upgrade."
 			`"I'll be sure it's done, captain," Maribelle replies.`
 				goto next
 
@@ -1464,56 +1464,56 @@ mission "Apoxys Level 15"
 			action
 				outfit "Shields I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 15" "Chose shield upgrade."
+				log Levels "Apoxys" "Level 15: Chose shield upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Only the strongest shields to keep the bad things out!"`
 				decline
 			label hullcap
 			action
 				outfit "Hull I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 15" "Chose hull upgrade."
+				log Levels "Apoxys" "Level 15: Chose hull upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. The most durable hull, for resisting all that space throws at us!"`
 				decline
 			label outfitcap
 			action
 				outfit "Outfit I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 15" "Chose outfit upgrade."
+				log Levels "Apoxys" "Level 15: Chose outfit upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Just imagine what we can do with all the extra space!"`
 				decline
 			label heatcap
 			action
 				outfit "Heat Capacity I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 15" "Chose heat capacity upgrade."
+				log Levels "Apoxys" "Level 15: Chose heat capacity upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Heat shouldn't be nearly as much of an issue, now!"`
 				decline
 			label weaponcap
 			action
 				outfit "Weapons I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 15" "Chose weapon upgrade."
+				log Levels "Apoxys" "Level 15: Chose weapon upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Our projectiles will blot out the sun! Maybe even a couple suns."`
 				decline
 			label enginecap
 			action
 				outfit "Engines I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 15" "Chose engine upgrade."
+				log Levels "Apoxys" "Level 15: Chose engine upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Our engines will move us like a moth to a flame! Ideally without the burning alive part."`
 				decline
 			label cargocap
 			action
 				outfit "Cargo I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 15" "Chose cargo upgrade."
+				log Levels "Apoxys" "Level 15: Chose cargo upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. We'll be able to carry plenty of goodies now!"`
 				decline
 			label bunkcap
 			action
 				outfit "Bunks I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 15" "Chose bunk upgrade."
+				log Levels "Apoxys" "Level 15: Chose bunk upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. We'll have room for all sorts of friends!"`
 				decline
 
@@ -1555,56 +1555,56 @@ mission "Apoxys Level 16"
 			action
 				outfit "Shields I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 16" "Chose shield upgrade."
+				log Levels "Apoxys" "Level 16: Chose shield upgrade."
 			`"More shields sound good, captain!" Maribelle replies giddily.`
 				goto next
 			label hullcap
 			action
 				outfit "Hull I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 16" "Chose hull upgrade."
+				log Levels "Apoxys" "Level 16: Chose hull upgrade."
 			`"More hull sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label outfitcap
 			action
 				outfit "Outfit I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 16" "Chose outfit upgrade."
+				log Levels "Apoxys" "Level 16: Chose outfit upgrade."
 			`"More space sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label heatcap
 			action
 				outfit "Heat Capacity I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 16" "Chose heat capacity upgrade."
+				log Levels "Apoxys" "Level 16: Chose heat capacity upgrade."
 			`"More heat capacity sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label weaponcap
 			action
 				outfit "Weapons I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 16" "Chose weapon upgrade."
+				log Levels "Apoxys" "Level 16: Chose weapon upgrade."
 			`"More weaponry sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label enginecap
 			action
 				outfit "Engines I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 16" "Chose engine upgrade."
+				log Levels "Apoxys" "Level 16: Chose engine upgrade."
 			`"More engine capabilities sound good, captain!" Maribelle replies giddily.`
 				goto next
 			label cargocap
 			action
 				outfit "Cargo I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 16" "Chose cargo upgrade."
+				log Levels "Apoxys" "Level 16: Chose cargo upgrade."
 			`"More carrying capacity sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label bunkcap
 			action
 				outfit "Bunks I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 16" "Chose bunk upgrade."
+				log Levels "Apoxys" "Level 16: Chose bunk upgrade."
 			`"I'll be sure it's done, captain," Maribelle replies.`
 				goto next
 
@@ -1651,56 +1651,56 @@ mission "Apoxys Level 17"
 			action
 				outfit "Shields I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 17" "Chose shield upgrade."
+				log Levels "Apoxys" "Level 17: Chose shield upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Only the strongest shields to keep the bad things out!"`
 				decline
 			label hullcap
 			action
 				outfit "Hull I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 17" "Chose hull upgrade."
+				log Levels "Apoxys" "Level 17: Chose hull upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. The most durable hull, for resisting all that space throws at us!"`
 				decline
 			label outfitcap
 			action
 				outfit "Outfit I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 17" "Chose outfit upgrade."
+				log Levels "Apoxys" "Level 17: Chose outfit upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Just imagine what we can do with all the extra space!"`
 				decline
 			label heatcap
 			action
 				outfit "Heat Capacity I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 17" "Chose heat capacity upgrade."
+				log Levels "Apoxys" "Level 17: Chose heat capacity upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Heat shouldn't be nearly as much of an issue, now!"`
 				decline
 			label weaponcap
 			action
 				outfit "Weapons I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 17" "Chose weapon upgrade."
+				log Levels "Apoxys" "Level 17: Chose weapon upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Our projectiles will blot out the sun! Maybe even a couple suns."`
 				decline
 			label enginecap
 			action
 				outfit "Engines I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 17" "Chose engine upgrade."
+				log Levels "Apoxys" "Level 17: Chose engine upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Our engines will move us like a moth to a flame! Ideally without the burning alive part."`
 				decline
 			label cargocap
 			action
 				outfit "Cargo I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 17" "Chose cargo upgrade."
+				log Levels "Apoxys" "Level 17: Chose cargo upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. We'll be able to carry plenty of goodies now!"`
 				decline
 			label bunkcap
 			action
 				outfit "Bunks I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 17" "Chose bunk upgrade."
+				log Levels "Apoxys" "Level 17: Chose bunk upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. We'll have room for all sorts of friends!"`
 				decline
 
@@ -1742,56 +1742,56 @@ mission "Apoxys Level 18"
 			action
 				outfit "Shields I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 18" "Chose shield upgrade."
+				log Levels "Apoxys" "Level 18: Chose shield upgrade."
 			`"More shields sound good, captain!" Maribelle replies giddily.`
 				goto next
 			label hullcap
 			action
 				outfit "Hull I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 18" "Chose hull upgrade."
+				log Levels "Apoxys" "Level 18: Chose hull upgrade."
 			`"More hull sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label outfitcap
 			action
 				outfit "Outfit I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 18" "Chose outfit upgrade."
+				log Levels "Apoxys" "Level 18: Chose outfit upgrade."
 			`"More space sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label heatcap
 			action
 				outfit "Heat Capacity I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 18" "Chose heat capacity upgrade."
+				log Levels "Apoxys" "Level 18: Chose heat capacity upgrade."
 			`"More heat capacity sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label weaponcap
 			action
 				outfit "Weapons I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 18" "Chose weapon upgrade."
+				log Levels "Apoxys" "Level 18: Chose weapon upgrade."
 			`"More weaponry sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label enginecap
 			action
 				outfit "Engines I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 18" "Chose engine upgrade."
+				log Levels "Apoxys" "Level 18: Chose engine upgrade."
 			`"More engine capabilities sound good, captain!" Maribelle replies giddily.`
 				goto next
 			label cargocap
 			action
 				outfit "Cargo I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 18" "Chose cargo upgrade."
+				log Levels "Apoxys" "Level 18: Chose cargo upgrade."
 			`"More carrying capacity sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label bunkcap
 			action
 				outfit "Bunks I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 18" "Chose bunk upgrade."
+				log Levels "Apoxys" "Level 18: Chose bunk upgrade."
 			`"I'll be sure it's done, captain," Maribelle replies.`
 				goto next
 
@@ -1838,56 +1838,56 @@ mission "Apoxys Level 19"
 			action
 				outfit "Shields I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 19" "Chose shield upgrade."
+				log Levels "Apoxys" "Level 19: Chose shield upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Only the strongest shields to keep the bad things out!"`
 				decline
 			label hullcap
 			action
 				outfit "Hull I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 19" "Chose hull upgrade."
+				log Levels "Apoxys" "Level 19: Chose hull upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. The most durable hull, for resisting all that space throws at us!"`
 				decline
 			label outfitcap
 			action
 				outfit "Outfit I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 19" "Chose outfit upgrade."
+				log Levels "Apoxys" "Level 19: Chose outfit upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Just imagine what we can do with all the extra space!"`
 				decline
 			label heatcap
 			action
 				outfit "Heat Capacity I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 19" "Chose heat capacity upgrade."
+				log Levels "Apoxys" "Level 19: Chose heat capacity upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Heat shouldn't be nearly as much of an issue, now!"`
 				decline
 			label weaponcap
 			action
 				outfit "Weapons I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 19" "Chose weapon upgrade."
+				log Levels "Apoxys" "Level 19: Chose weapon upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Our projectiles will blot out the sun! Maybe even a couple suns."`
 				decline
 			label enginecap
 			action
 				outfit "Engines I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 19" "Chose engine upgrade."
+				log Levels "Apoxys" "Level 19: Chose engine upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Our engines will move us like a moth to a flame! Ideally without the burning alive part."`
 				decline
 			label cargocap
 			action
 				outfit "Cargo I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 19" "Chose cargo upgrade."
+				log Levels "Apoxys" "Level 19: Chose cargo upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. We'll be able to carry plenty of goodies now!"`
 				decline
 			label bunkcap
 			action
 				outfit "Bunks I" 1
 				outfit "Basal Level I" 1
-				log Levels "Level 19" "Chose bunk upgrade."
+				log Levels "Apoxys" "Level 19: Chose bunk upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. We'll have room for all sorts of friends!"`
 				decline
 
@@ -1930,56 +1930,56 @@ mission "Apoxys Level 20"
 			action
 				outfit "Shields I" 1
 				outfit "Milestone I" 1
-				log Levels "Level 20" "Chose shield upgrade."
+				log Levels "Apoxys" "Level 20: Chose shield upgrade."
 			`"I'll be sure to delegate some energy to that!" Maribelle says, still shaking excitedly.`
 				goto next
 			label hullcap
 			action
 				outfit "Hull I" 1
 				outfit "Milestone I" 1
-				log Levels "Level 20" "Chose hull upgrade."
+				log Levels "Apoxys" "Level 20: Chose hull upgrade."
 			`"I'll be sure to delegate some energy to that!" Maribelle says, still shaking excitedly.`
 				goto next
 			label outfitcap
 			action
 				outfit "Outfit I" 1
 				outfit "Milestone I" 1
-				log Levels "Level 20" "Chose outfit upgrade."
+				log Levels "Apoxys" "Level 20: Chose outfit upgrade."
 			`"I'll be sure to delegate some energy to that!" Maribelle says, still shaking excitedly.`
 				goto next
 			label heatcap
 			action
 				outfit "Heat Capacity I" 1
 				outfit "Milestone I" 1
-				log Levels "Level 20" "Chose heat capacity upgrade."
+				log Levels "Apoxys" "Level 20: Chose heat capacity upgrade."
 			`"I'll be sure to delegate some energy to that!" Maribelle says, still shaking excitedly.`
 				goto next
 			label weaponcap
 			action
 				outfit "Weapons I" 1
 				outfit "Milestone I" 1
-				log Levels "Level 20" "Chose weapon upgrade."
+				log Levels "Apoxys" "Level 20: Chose weapon upgrade."
 			`"I'll be sure to delegate some energy to that!" Maribelle says, still shaking excitedly.`
 				goto next
 			label enginecap
 			action
 				outfit "Engines I" 1
 				outfit "Milestone I" 1
-				log Levels "Level 20" "Chose engine upgrade."
+				log Levels "Apoxys" "Level 20: Chose engine upgrade."
 			`"I'll be sure to delegate some energy to that!" Maribelle says, still shaking excitedly.`
 				goto next
 			label cargocap
 			action
 				outfit "Cargo I" 1
 				outfit "Milestone I" 1
-				log Levels "Level 20" "Chose cargo upgrade."
+				log Levels "Apoxys" "Level 20: Chose cargo upgrade."
 			`"I'll be sure to delegate some energy to that!" Maribelle says, still shaking excitedly.`
 				goto next
 			label bunkcap
 			action
 				outfit "Bunks I" 1
 				outfit "Milestone I" 1
-				log Levels "Level 20" "Chose bunk upgrade."
+				log Levels "Apoxys" "Level 20: Chose bunk upgrade."
 			`"I'll be sure to delegate some energy to that!" Maribelle says, still shaking excitedly.`
 				goto next
 

--- a/data/apoxys/levels101.txt
+++ b/data/apoxys/levels101.txt
@@ -129,6 +129,7 @@ mission "Apoxys Level 100+"
 	on offer
 		require "Apoxys Core DX"
 		conversation
+			action
 			`Maribelle (the Apoxys' AI) seems very content as you come in for landing. "Captain!" She exclaims excitedly, "I know we've only just begun, but I think I'm already beginning to understand the galaxy. If you don't mind, I'd like to make some adjustments while we're parked today."`
 			`You notice a number of prompts before you. You could likely give Maribelle some feedback into what exactly you'd like to improve. You begin to say, "In addition to your own desired improvements..."`
 			choice

--- a/data/apoxys/levels21-40.txt
+++ b/data/apoxys/levels21-40.txt
@@ -154,56 +154,56 @@ mission "Apoxys Level 21"
 			action
 				outfit "Shields II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 21" "Chose shield upgrade."
+				log Levels "Apoxys" "Level 21: Chose shield upgrade."
 			`"Oh!" Maribelle replies, seemingly a bit surprised that you cared to give your own input, "I'll do just that, then Captain. Only the strongest shields to keep the bad things out!"`
 				decline
 			label hullcap
 			action
 				outfit "Hull II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 21" "Chose hull upgrade."
+				log Levels "Apoxys" "Level 21: Chose hull upgrade."
 			`"Oh!" Maribelle replies, seemingly a bit surprised that you cared to give your own input, "I'll do just that, then Captain. The most durable hull, for resisting all that space throws at us!"`
 				decline
 			label outfitcap
 			action
 				outfit "Outfit II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 21" "Chose outfit upgrade."
+				log Levels "Apoxys" "Level 21: Chose outfit upgrade."
 			`"Oh!" Maribelle replies, seemingly a bit surprised that you cared to give your own input, "I'll do just that, then Captain. Just imagine what we can do with all the extra space!"`
 				decline
 			label heatcap
 			action
 				outfit "Heat Capacity II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 21" "Chose heat capacity upgrade."
+				log Levels "Apoxys" "Level 21: Chose heat capacity upgrade."
 			`"Oh!" Maribelle replies, seemingly a bit surprised that you cared to give your own input, "I'll do just that, then Captain. No heat will be too mighty for our heatsinks!"`
 				decline
 			label weaponcap
 			action
 				outfit "Weapons II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 21" "Chose weapon upgrade."
+				log Levels "Apoxys" "Level 21: Chose weapon upgrade."
 			`"Oh!" Maribelle replies, seemingly a bit surprised that you cared to give your own input, "I'll do just that, then Captain. Our projectiles will blot out the sun! Maybe even a couple suns."`
 				decline
 			label enginecap
 			action
 				outfit "Engines II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 21" "Chose engine upgrade."
+				log Levels "Apoxys" "Level 21: Chose engine upgrade."
 			`"Oh!" Maribelle replies, seemingly a bit surprised that you cared to give your own input, "I'll do just that, then Captain. Our engines will move us like a moth to a flame! Ideally without the burning alive part."`
 				decline
 			label cargocap
 			action
 				outfit "Cargo II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 21" "Chose cargo upgrade."
+				log Levels "Apoxys" "Level 21: Chose cargo upgrade."
 			`"Oh!" Maribelle replies, seemingly a bit surprised that you cared to give your own input, "I'll do just that, then Captain. We'll be able to carry plenty of goodies now!"`
 				decline
 			label bunkcap
 			action
 				outfit "Bunks II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 21" "Chose bunk upgrade."
+				log Levels "Apoxys" "Level 21: Chose bunk upgrade."
 			`"Oh!" Maribelle replies, seemingly a bit surprised that you cared to give your own input, "I'll do just that, then Captain. We'll have room for all sorts of friends!"`
 				decline
 
@@ -244,56 +244,56 @@ mission "Apoxys Level 22"
 			action
 				outfit "Shields II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 22" "Chose shield upgrade."
+				log Levels "Apoxys" "Level 22: Chose shield upgrade."
 			`"I'll be sure it's done, captain," Maribelle replies.`
 				goto next
 			label hullcap
 			action
 				outfit "Hull II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 22" "Chose hull upgrade."
+				log Levels "Apoxys" "Level 22: Chose hull upgrade."
 			`"I'll be sure it's done, captain," Maribelle replies.`
 				goto next
 			label outfitcap
 			action
 				outfit "Outfit II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 22" "Chose outfit upgrade."
+				log Levels "Apoxys" "Level 22: Chose outfit upgrade."
 			`"I'll be sure it's done, captain," Maribelle replies.`
 				goto next
 			label heatcap
 			action
 				outfit "Heat Capacity II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 22" "Chose heat capacity upgrade."
+				log Levels "Apoxys" "Level 22: Chose heat capacity upgrade."
 			`"I'll be sure it's done, captain," Maribelle replies.`
 				goto next
 			label weaponcap
 			action
 				outfit "Weapons II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 22" "Chose weapon upgrade."
+				log Levels "Apoxys" "Level 22: Chose weapon upgrade."
 			`"I'll be sure it's done, captain," Maribelle replies.`
 				goto next
 			label enginecap
 			action
 				outfit "Engines II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 22" "Chose engine upgrade."
+				log Levels "Apoxys" "Level 22: Chose engine upgrade."
 			`"I'll be sure it's done, captain," Maribelle replies.`
 				goto next
 			label cargocap
 			action
 				outfit "Cargo II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 22" "Chose cargo upgrade."
+				log Levels "Apoxys" "Level 22: Chose cargo upgrade."
 			`"I'll be sure it's done, captain," Maribelle replies.`
 				goto next
 			label bunkcap
 			action
 				outfit "Bunks II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 22" "Chose bunk upgrade."
+				log Levels "Apoxys" "Level 22: Chose bunk upgrade."
 			`"I'll be sure it's done, captain," Maribelle replies.`
 				goto next
 
@@ -341,56 +341,56 @@ mission "Apoxys Level 23"
 			action
 				outfit "Shields II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 23" "Chose shield upgrade."
+				log Levels "Apoxys" "Level 23: Chose shield upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Only the strongest shields to keep the bad things out!"`
 				decline
 			label hullcap
 			action
 				outfit "Hull II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 23" "Chose hull upgrade."
+				log Levels "Apoxys" "Level 23: Chose hull upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. The most durable hull, for resisting all that space throws at us!"`
 				decline
 			label outfitcap
 			action
 				outfit "Outfit II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 23" "Chose outfit upgrade."
+				log Levels "Apoxys" "Level 23: Chose outfit upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Just imagine what we can do with all the extra space!"`
 				decline
 			label heatcap
 			action
 				outfit "Heat Capacity II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 23" "Chose heat capacity upgrade."
+				log Levels "Apoxys" "Level 23: Chose heat capacity upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Heat shouldn't be nearly as much of an issue, now!"`
 				decline
 			label weaponcap
 			action
 				outfit "Weapons II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 23" "Chose weapon upgrade."
+				log Levels "Apoxys" "Level 23: Chose weapon upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Our projectiles will blot out the sun! Maybe even a couple suns."`
 				decline
 			label enginecap
 			action
 				outfit "Engines II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 23" "Chose engine upgrade."
+				log Levels "Apoxys" "Level 23: Chose engine upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Our engines will move us like a moth to a flame! Ideally without the burning alive part."`
 				decline
 			label cargocap
 			action
 				outfit "Cargo II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 23" "Chose cargo upgrade."
+				log Levels "Apoxys" "Level 23: Chose cargo upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. We'll be able to carry plenty of goodies now!"`
 				decline
 			label bunkcap
 			action
 				outfit "Bunks II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 23" "Chose bunk upgrade."
+				log Levels "Apoxys" "Level 23: Chose bunk upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. We'll have room for all sorts of friends!"`
 				decline
 
@@ -432,56 +432,56 @@ mission "Apoxys Level 24"
 			action
 				outfit "Shields II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 24" "Chose shield upgrade."
+				log Levels "Apoxys" "Level 24: Chose shield upgrade."
 			`"More shields sound good, captain!" Maribelle replies giddily.`
 				goto next
 			label hullcap
 			action
 				outfit "Hull II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 24" "Chose hull upgrade."
+				log Levels "Apoxys" "Level 24: Chose hull upgrade."
 			`"More hull sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label outfitcap
 			action
 				outfit "Outfit II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 24" "Chose outfit upgrade."
+				log Levels "Apoxys" "Level 24: Chose outfit upgrade."
 			`"More space sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label heatcap
 			action
 				outfit "Heat Capacity II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 24" "Chose heat capacity upgrade."
+				log Levels "Apoxys" "Level 24: Chose heat capacity upgrade."
 			`"More heat capacity sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label weaponcap
 			action
 				outfit "Weapons II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 24" "Chose weapon upgrade."
+				log Levels "Apoxys" "Level 24: Chose weapon upgrade."
 			`"More weaponry sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label enginecap
 			action
 				outfit "Engines II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 24" "Chose engine upgrade."
+				log Levels "Apoxys" "Level 24: Chose engine upgrade."
 			`"More engine capabilities sound good, captain!" Maribelle replies giddily.`
 				goto next
 			label cargocap
 			action
 				outfit "Cargo II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 24" "Chose cargo upgrade."
+				log Levels "Apoxys" "Level 24: Chose cargo upgrade."
 			`"More carrying capacity sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label bunkcap
 			action
 				outfit "Bunks II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 24" "Chose bunk upgrade."
+				log Levels "Apoxys" "Level 24: Chose bunk upgrade."
 			`"I'll be sure it's done, captain," Maribelle replies.`
 				goto next
 
@@ -528,56 +528,56 @@ mission "Apoxys Level 25"
 			action
 				outfit "Shields II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 25" "Chose shield upgrade."
+				log Levels "Apoxys" "Level 25: Chose shield upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Only the strongest shields to keep the bad things out!"`
 				decline
 			label hullcap
 			action
 				outfit "Hull II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 25" "Chose hull upgrade."
+				log Levels "Apoxys" "Level 25: Chose hull upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. The most durable hull, for resisting all that space throws at us!"`
 				decline
 			label outfitcap
 			action
 				outfit "Outfit II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 25" "Chose outfit upgrade."
+				log Levels "Apoxys" "Level 25: Chose outfit upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Just imagine what we can do with all the extra space!"`
 				decline
 			label heatcap
 			action
 				outfit "Heat Capacity II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 25" "Chose heat capacity upgrade."
+				log Levels "Apoxys" "Level 25: Chose heat capacity upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Heat shouldn't be nearly as much of an issue, now!"`
 				decline
 			label weaponcap
 			action
 				outfit "Weapons II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 25" "Chose weapon upgrade."
+				log Levels "Apoxys" "Level 25: Chose weapon upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Our projectiles will blot out the sun! Maybe even a couple suns."`
 				decline
 			label enginecap
 			action
 				outfit "Engines II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 25" "Chose engine upgrade."
+				log Levels "Apoxys" "Level 25: Chose engine upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Our engines will move us like a moth to a flame! Ideally without the burning alive part."`
 				decline
 			label cargocap
 			action
 				outfit "Cargo II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 25" "Chose cargo upgrade."
+				log Levels "Apoxys" "Level 25: Chose cargo upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. We'll be able to carry plenty of goodies now!"`
 				decline
 			label bunkcap
 			action
 				outfit "Bunks II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 25" "Chose bunk upgrade."
+				log Levels "Apoxys" "Level 25: Chose bunk upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. We'll have room for all sorts of friends!"`
 				decline
 
@@ -619,56 +619,56 @@ mission "Apoxys Level 26"
 			action
 				outfit "Shields II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 26" "Chose shield upgrade."
+				log Levels "Apoxys" "Level 26: Chose shield upgrade."
 			`"More shields sound good, captain!" Maribelle replies giddily.`
 				goto next
 			label hullcap
 			action
 				outfit "Hull II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 26" "Chose hull upgrade."
+				log Levels "Apoxys" "Level 26: Chose hull upgrade."
 			`"More hull sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label outfitcap
 			action
 				outfit "Outfit II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 26" "Chose outfit upgrade."
+				log Levels "Apoxys" "Level 26: Chose outfit upgrade."
 			`"More space sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label heatcap
 			action
 				outfit "Heat Capacity II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 26" "Chose heat capacity upgrade."
+				log Levels "Apoxys" "Level 26: Chose heat capacity upgrade."
 			`"More heat capacity sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label weaponcap
 			action
 				outfit "Weapons II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 26" "Chose weapon upgrade."
+				log Levels "Apoxys" "Level 26: Chose weapon upgrade."
 			`"More weaponry sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label enginecap
 			action
 				outfit "Engines II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 26" "Chose engine upgrade."
+				log Levels "Apoxys" "Level 26: Chose engine upgrade."
 			`"More engine capabilities sound good, captain!" Maribelle replies giddily.`
 				goto next
 			label cargocap
 			action
 				outfit "Cargo II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 26" "Chose cargo upgrade."
+				log Levels "Apoxys" "Level 26: Chose cargo upgrade."
 			`"More carrying capacity sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label bunkcap
 			action
 				outfit "Bunks II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 26" "Chose bunk upgrade."
+				log Levels "Apoxys" "Level 26: Chose bunk upgrade."
 			`"I'll be sure it's done, captain," Maribelle replies.`
 				goto next
 
@@ -715,56 +715,56 @@ mission "Apoxys Level 27"
 			action
 				outfit "Shields II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 27" "Chose shield upgrade."
+				log Levels "Apoxys" "Level 27: Chose shield upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Only the strongest shields to keep the bad things out!"`
 				decline
 			label hullcap
 			action
 				outfit "Hull II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 27" "Chose hull upgrade."
+				log Levels "Apoxys" "Level 27: Chose hull upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. The most durable hull, for resisting all that space throws at us!"`
 				decline
 			label outfitcap
 			action
 				outfit "Outfit II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 27" "Chose outfit upgrade."
+				log Levels "Apoxys" "Level 27: Chose outfit upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Just imagine what we can do with all the extra space!"`
 				decline
 			label heatcap
 			action
 				outfit "Heat Capacity II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 27" "Chose heat capacity upgrade."
+				log Levels "Apoxys" "Level 27: Chose heat capacity upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Heat shouldn't be nearly as much of an issue, now!"`
 				decline
 			label weaponcap
 			action
 				outfit "Weapons II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 27" "Chose weapon upgrade."
+				log Levels "Apoxys" "Level 27: Chose weapon upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Our projectiles will blot out the sun! Maybe even a couple suns."`
 				decline
 			label enginecap
 			action
 				outfit "Engines II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 27" "Chose engine upgrade."
+				log Levels "Apoxys" "Level 27: Chose engine upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Our engines will move us like a moth to a flame! Ideally without the burning alive part."`
 				decline
 			label cargocap
 			action
 				outfit "Cargo II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 27" "Chose cargo upgrade."
+				log Levels "Apoxys" "Level 27: Chose cargo upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. We'll be able to carry plenty of goodies now!"`
 				decline
 			label bunkcap
 			action
 				outfit "Bunks II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 27" "Chose bunk upgrade."
+				log Levels "Apoxys" "Level 27: Chose bunk upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. We'll have room for all sorts of friends!"`
 				decline
 
@@ -806,56 +806,56 @@ mission "Apoxys Level 28"
 			action
 				outfit "Shields II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 28" "Chose shield upgrade."
+				log Levels "Apoxys" "Level 28: Chose shield upgrade."
 			`"More shields sound good, captain!" Maribelle replies giddily.`
 				goto next
 			label hullcap
 			action
 				outfit "Hull II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 28" "Chose hull upgrade."
+				log Levels "Apoxys" "Level 28: Chose hull upgrade."
 			`"More hull sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label outfitcap
 			action
 				outfit "Outfit II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 28" "Chose outfit upgrade."
+				log Levels "Apoxys" "Level 28: Chose outfit upgrade."
 			`"More space sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label heatcap
 			action
 				outfit "Heat Capacity II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 28" "Chose heat capacity upgrade."
+				log Levels "Apoxys" "Level 28: Chose heat capacity upgrade."
 			`"More heat capacity sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label weaponcap
 			action
 				outfit "Weapons II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 28" "Chose weapon upgrade."
+				log Levels "Apoxys" "Level 28: Chose weapon upgrade."
 			`"More weaponry sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label enginecap
 			action
 				outfit "Engines II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 28" "Chose engine upgrade."
+				log Levels "Apoxys" "Level 28: Chose engine upgrade."
 			`"More engine capabilities sound good, captain!" Maribelle replies giddily.`
 				goto next
 			label cargocap
 			action
 				outfit "Cargo II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 28" "Chose cargo upgrade."
+				log Levels "Apoxys" "Level 28: Chose cargo upgrade."
 			`"More carrying capacity sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label bunkcap
 			action
 				outfit "Bunks II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 28" "Chose bunk upgrade."
+				log Levels "Apoxys" "Level 28: Chose bunk upgrade."
 			`"I'll be sure it's done, captain," Maribelle replies.`
 				goto next
 
@@ -902,56 +902,56 @@ mission "Apoxys Level 29"
 			action
 				outfit "Shields II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 29" "Chose shield upgrade."
+				log Levels "Apoxys" "Level 29: Chose shield upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Only the strongest shields to keep the bad things out!"`
 				decline
 			label hullcap
 			action
 				outfit "Hull II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 29" "Chose hull upgrade."
+				log Levels "Apoxys" "Level 29: Chose hull upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. The most durable hull, for resisting all that space throws at us!"`
 				decline
 			label outfitcap
 			action
 				outfit "Outfit II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 29" "Chose outfit upgrade."
+				log Levels "Apoxys" "Level 29: Chose outfit upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Just imagine what we can do with all the extra space!"`
 				decline
 			label heatcap
 			action
 				outfit "Heat Capacity II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 29" "Chose heat capacity upgrade."
+				log Levels "Apoxys" "Level 29: Chose heat capacity upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Heat shouldn't be nearly as much of an issue, now!"`
 				decline
 			label weaponcap
 			action
 				outfit "Weapons II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 29" "Chose weapon upgrade."
+				log Levels "Apoxys" "Level 29: Chose weapon upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Our projectiles will blot out the sun! Maybe even a couple suns."`
 				decline
 			label enginecap
 			action
 				outfit "Engines II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 29" "Chose engine upgrade."
+				log Levels "Apoxys" "Level 29: Chose engine upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Our engines will move us like a moth to a flame! Ideally without the burning alive part."`
 				decline
 			label cargocap
 			action
 				outfit "Cargo II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 29" "Chose cargo upgrade."
+				log Levels "Apoxys" "Level 29: Chose cargo upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. We'll be able to carry plenty of goodies now!"`
 				decline
 			label bunkcap
 			action
 				outfit "Bunks II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 29" "Chose bunk upgrade."
+				log Levels "Apoxys" "Level 29: Chose bunk upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. We'll have room for all sorts of friends!"`
 				decline
 
@@ -994,56 +994,56 @@ mission "Apoxys Level 30"
 			action
 				outfit "Shields II" 1
 				outfit "Milestone II" 1
-				log Levels "Level 30" "Chose shield upgrade."
+				log Levels "Apoxys" "Level 30: Chose shield upgrade."
 			`"I'll be sure to delegate some energy to that!" Maribelle says, still shaking excitedly.`
 				goto next
 			label hullcap
 			action
 				outfit "Hull II" 1
 				outfit "Milestone II" 1
-				log Levels "Level 30" "Chose hull upgrade."
+				log Levels "Apoxys" "Level 30: Chose hull upgrade."
 			`"I'll be sure to delegate some energy to that!" Maribelle says, still shaking excitedly.`
 				goto next
 			label outfitcap
 			action
 				outfit "Outfit II" 1
 				outfit "Milestone II" 1
-				log Levels "Level 30" "Chose outfit upgrade."
+				log Levels "Apoxys" "Level 30: Chose outfit upgrade."
 			`"I'll be sure to delegate some energy to that!" Maribelle says, still shaking excitedly.`
 				goto next
 			label heatcap
 			action
 				outfit "Heat Capacity II" 1
 				outfit "Milestone II" 1
-				log Levels "Level 30" "Chose heat capacity upgrade."
+				log Levels "Apoxys" "Level 30: Chose heat capacity upgrade."
 			`"I'll be sure to delegate some energy to that!" Maribelle says, still shaking excitedly.`
 				goto next
 			label weaponcap
 			action
 				outfit "Weapons II" 1
 				outfit "Milestone II" 1
-				log Levels "Level 30" "Chose weapon upgrade."
+				log Levels "Apoxys" "Level 30: Chose weapon upgrade."
 			`"I'll be sure to delegate some energy to that!" Maribelle says, still shaking excitedly.`
 				goto next
 			label enginecap
 			action
 				outfit "Engines II" 1
 				outfit "Milestone II" 1
-				log Levels "Level 30" "Chose engine upgrade."
+				log Levels "Apoxys" "Level 30: Chose engine upgrade."
 			`"I'll be sure to delegate some energy to that!" Maribelle says, still shaking excitedly.`
 				goto next
 			label cargocap
 			action
 				outfit "Cargo II" 1
 				outfit "Milestone II" 1
-				log Levels "Level 30" "Chose cargo upgrade."
+				log Levels "Apoxys" "Level 30: Chose cargo upgrade."
 			`"I'll be sure to delegate some energy to that!" Maribelle says, still shaking excitedly.`
 				goto next
 			label bunkcap
 			action
 				outfit "Bunks II" 1
 				outfit "Milestone II" 1
-				log Levels "Level 30" "Chose bunk upgrade."
+				log Levels "Apoxys" "Level 30: Chose bunk upgrade."
 			`"I'll be sure to delegate some energy to that!" Maribelle says, still shaking excitedly.`
 				goto next
 
@@ -1090,56 +1090,56 @@ mission "Apoxys Level 31"
 			action
 				outfit "Shields II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 31" "Chose shield upgrade."
+				log Levels "Apoxys" "Level 31: Chose shield upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Only the strongest shields to keep the bad things out!"`
 				decline
 			label hullcap
 			action
 				outfit "Hull II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 31" "Chose hull upgrade."
+				log Levels "Apoxys" "Level 31: Chose hull upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. The most durable hull, for resisting all that space throws at us!"`
 				decline
 			label outfitcap
 			action
 				outfit "Outfit II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 31" "Chose outfit upgrade."
+				log Levels "Apoxys" "Level 31: Chose outfit upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Just imagine what we can do with all the extra space!"`
 				decline
 			label heatcap
 			action
 				outfit "Heat Capacity II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 31" "Chose heat capacity upgrade."
+				log Levels "Apoxys" "Level 31: Chose heat capacity upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Heat shouldn't be nearly as much of an issue, now!"`
 				decline
 			label weaponcap
 			action
 				outfit "Weapons II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 31" "Chose weapon upgrade."
+				log Levels "Apoxys" "Level 31: Chose weapon upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Our projectiles will blot out the sun! Maybe even a couple suns."`
 				decline
 			label enginecap
 			action
 				outfit "Engines II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 31" "Chose engine upgrade."
+				log Levels "Apoxys" "Level 31: Chose engine upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Our engines will move us like a moth to a flame! Ideally without the burning alive part."`
 				decline
 			label cargocap
 			action
 				outfit "Cargo II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 31" "Chose cargo upgrade."
+				log Levels "Apoxys" "Level 31: Chose cargo upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. We'll be able to carry plenty of goodies now!"`
 				decline
 			label bunkcap
 			action
 				outfit "Bunks II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 31" "Chose bunk upgrade."
+				log Levels "Apoxys" "Level 31: Chose bunk upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. We'll have room for all sorts of friends!"`
 				decline
 
@@ -1181,56 +1181,56 @@ mission "Apoxys Level 32"
 			action
 				outfit "Shields II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 32" "Chose shield upgrade."
+				log Levels "Apoxys" "Level 32: Chose shield upgrade."
 			`"I'll be sure it's done, captain," Maribelle replies.`
 				goto next
 			label hullcap
 			action
 				outfit "Hull II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 32" "Chose hull upgrade."
+				log Levels "Apoxys" "Level 32: Chose hull upgrade."
 			`"I'll be sure it's done, captain," Maribelle replies.`
 				goto next
 			label outfitcap
 			action
 				outfit "Outfit II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 32" "Chose outfit upgrade."
+				log Levels "Apoxys" "Level 32: Chose outfit upgrade."
 			`"I'll be sure it's done, captain," Maribelle replies.`
 				goto next
 			label heatcap
 			action
 				outfit "Heat Capacity II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 32" "Chose heat capacity upgrade."
+				log Levels "Apoxys" "Level 32: Chose heat capacity upgrade."
 			`"I'll be sure it's done, captain," Maribelle replies.`
 				goto next
 			label weaponcap
 			action
 				outfit "Weapons II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 32" "Chose weapon upgrade."
+				log Levels "Apoxys" "Level 32: Chose weapon upgrade."
 			`"I'll be sure it's done, captain," Maribelle replies.`
 				goto next
 			label enginecap
 			action
 				outfit "Engines II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 32" "Chose engine upgrade."
+				log Levels "Apoxys" "Level 32: Chose engine upgrade."
 			`"I'll be sure it's done, captain," Maribelle replies.`
 				goto next
 			label cargocap
 			action
 				outfit "Cargo II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 32" "Chose cargo upgrade."
+				log Levels "Apoxys" "Level 32: Chose cargo upgrade."
 			`"I'll be sure it's done, captain," Maribelle replies.`
 				goto next
 			label bunkcap
 			action
 				outfit "Bunks II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 32" "Chose bunk upgrade."
+				log Levels "Apoxys" "Level 32: Chose bunk upgrade."
 			`"I'll be sure it's done, captain," Maribelle replies.`
 				goto next
 
@@ -1278,56 +1278,56 @@ mission "Apoxys Level 33"
 			action
 				outfit "Shields II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 33" "Chose shield upgrade."
+				log Levels "Apoxys" "Level 33: Chose shield upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Only the strongest shields to keep the bad things out!"`
 				decline
 			label hullcap
 			action
 				outfit "Hull II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 33" "Chose hull upgrade."
+				log Levels "Apoxys" "Level 33: Chose hull upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. The most durable hull, for resisting all that space throws at us!"`
 				decline
 			label outfitcap
 			action
 				outfit "Outfit II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 33" "Chose outfit upgrade."
+				log Levels "Apoxys" "Level 33: Chose outfit upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Just imagine what we can do with all the extra space!"`
 				decline
 			label heatcap
 			action
 				outfit "Heat Capacity II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 33" "Chose heat capacity upgrade."
+				log Levels "Apoxys" "Level 33: Chose heat capacity upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Heat shouldn't be nearly as much of an issue, now!"`
 				decline
 			label weaponcap
 			action
 				outfit "Weapons II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 33" "Chose weapon upgrade."
+				log Levels "Apoxys" "Level 33: Chose weapon upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Our projectiles will blot out the sun! Maybe even a couple suns."`
 				decline
 			label enginecap
 			action
 				outfit "Engines II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 33" "Chose engine upgrade."
+				log Levels "Apoxys" "Level 33: Chose engine upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Our engines will move us like a moth to a flame! Ideally without the burning alive part."`
 				decline
 			label cargocap
 			action
 				outfit "Cargo II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 33" "Chose cargo upgrade."
+				log Levels "Apoxys" "Level 33: Chose cargo upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. We'll be able to carry plenty of goodies now!"`
 				decline
 			label bunkcap
 			action
 				outfit "Bunks II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 33" "Chose bunk upgrade."
+				log Levels "Apoxys" "Level 33: Chose bunk upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. We'll have room for all sorts of friends!"`
 				decline
 
@@ -1369,56 +1369,56 @@ mission "Apoxys Level 34"
 			action
 				outfit "Shields II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 34" "Chose shield upgrade."
+				log Levels "Apoxys" "Level 34: Chose shield upgrade."
 			`"More shields sound good, captain!" Maribelle replies giddily.`
 				goto next
 			label hullcap
 			action
 				outfit "Hull II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 34" "Chose hull upgrade."
+				log Levels "Apoxys" "Level 34: Chose hull upgrade."
 			`"More hull sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label outfitcap
 			action
 				outfit "Outfit II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 34" "Chose outfit upgrade."
+				log Levels "Apoxys" "Level 34: Chose outfit upgrade."
 			`"More space sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label heatcap
 			action
 				outfit "Heat Capacity II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 34" "Chose heat capacity upgrade."
+				log Levels "Apoxys" "Level 34: Chose heat capacity upgrade."
 			`"More heat capacity sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label weaponcap
 			action
 				outfit "Weapons II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 34" "Chose weapon upgrade."
+				log Levels "Apoxys" "Level 34: Chose weapon upgrade."
 			`"More weaponry sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label enginecap
 			action
 				outfit "Engines II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 34" "Chose engine upgrade."
+				log Levels "Apoxys" "Level 34: Chose engine upgrade."
 			`"More engine capabilities sound good, captain!" Maribelle replies giddily.`
 				goto next
 			label cargocap
 			action
 				outfit "Cargo II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 34" "Chose cargo upgrade."
+				log Levels "Apoxys" "Level 34: Chose cargo upgrade."
 			`"More carrying capacity sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label bunkcap
 			action
 				outfit "Bunks II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 34" "Chose bunk upgrade."
+				log Levels "Apoxys" "Level 34: Chose bunk upgrade."
 			`"I'll be sure it's done, captain," Maribelle replies.`
 				goto next
 
@@ -1465,56 +1465,56 @@ mission "Apoxys Level 35"
 			action
 				outfit "Shields II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 35" "Chose shield upgrade."
+				log Levels "Apoxys" "Level 35: Chose shield upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Only the strongest shields to keep the bad things out!"`
 				decline
 			label hullcap
 			action
 				outfit "Hull II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 35" "Chose hull upgrade."
+				log Levels "Apoxys" "Level 35: Chose hull upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. The most durable hull, for resisting all that space throws at us!"`
 				decline
 			label outfitcap
 			action
 				outfit "Outfit II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 35" "Chose outfit upgrade."
+				log Levels "Apoxys" "Level 35: Chose outfit upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Just imagine what we can do with all the extra space!"`
 				decline
 			label heatcap
 			action
 				outfit "Heat Capacity II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 35" "Chose heat capacity upgrade."
+				log Levels "Apoxys" "Level 35: Chose heat capacity upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Heat shouldn't be nearly as much of an issue, now!"`
 				decline
 			label weaponcap
 			action
 				outfit "Weapons II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 35" "Chose weapon upgrade."
+				log Levels "Apoxys" "Level 35: Chose weapon upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Our projectiles will blot out the sun! Maybe even a couple suns."`
 				decline
 			label enginecap
 			action
 				outfit "Engines II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 35" "Chose engine upgrade."
+				log Levels "Apoxys" "Level 35: Chose engine upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Our engines will move us like a moth to a flame! Ideally without the burning alive part."`
 				decline
 			label cargocap
 			action
 				outfit "Cargo II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 35" "Chose cargo upgrade."
+				log Levels "Apoxys" "Level 35: Chose cargo upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. We'll be able to carry plenty of goodies now!"`
 				decline
 			label bunkcap
 			action
 				outfit "Bunks II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 35" "Chose bunk upgrade."
+				log Levels "Apoxys" "Level 35: Chose bunk upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. We'll have room for all sorts of friends!"`
 				decline
 
@@ -1556,56 +1556,56 @@ mission "Apoxys Level 36"
 			action
 				outfit "Shields II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 36" "Chose shield upgrade."
+				log Levels "Apoxys" "Level 36: Chose shield upgrade."
 			`"More shields sound good, captain!" Maribelle replies giddily.`
 				goto next
 			label hullcap
 			action
 				outfit "Hull II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 36" "Chose hull upgrade."
+				log Levels "Apoxys" "Level 36: Chose hull upgrade."
 			`"More hull sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label outfitcap
 			action
 				outfit "Outfit II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 36" "Chose outfit upgrade."
+				log Levels "Apoxys" "Level 36: Chose outfit upgrade."
 			`"More space sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label heatcap
 			action
 				outfit "Heat Capacity II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 36" "Chose heat capacity upgrade."
+				log Levels "Apoxys" "Level 36: Chose heat capacity upgrade."
 			`"More heat capacity sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label weaponcap
 			action
 				outfit "Weapons II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 36" "Chose weapon upgrade."
+				log Levels "Apoxys" "Level 36: Chose weapon upgrade."
 			`"More weaponry sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label enginecap
 			action
 				outfit "Engines II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 36" "Chose engine upgrade."
+				log Levels "Apoxys" "Level 36: Chose engine upgrade."
 			`"More engine capabilities sound good, captain!" Maribelle replies giddily.`
 				goto next
 			label cargocap
 			action
 				outfit "Cargo II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 36" "Chose cargo upgrade."
+				log Levels "Apoxys" "Level 36: Chose cargo upgrade."
 			`"More carrying capacity sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label bunkcap
 			action
 				outfit "Bunks II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 36" "Chose bunk upgrade."
+				log Levels "Apoxys" "Level 36: Chose bunk upgrade."
 			`"I'll be sure it's done, captain," Maribelle replies.`
 				goto next
 
@@ -1652,56 +1652,56 @@ mission "Apoxys Level 37"
 			action
 				outfit "Shields II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 37" "Chose shield upgrade."
+				log Levels "Apoxys" "Level 37: Chose shield upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Only the strongest shields to keep the bad things out!"`
 				decline
 			label hullcap
 			action
 				outfit "Hull II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 37" "Chose hull upgrade."
+				log Levels "Apoxys" "Level 37: Chose hull upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. The most durable hull, for resisting all that space throws at us!"`
 				decline
 			label outfitcap
 			action
 				outfit "Outfit II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 37" "Chose outfit upgrade."
+				log Levels "Apoxys" "Level 37: Chose outfit upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Just imagine what we can do with all the extra space!"`
 				decline
 			label heatcap
 			action
 				outfit "Heat Capacity II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 37" "Chose heat capacity upgrade."
+				log Levels "Apoxys" "Level 37: Chose heat capacity upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Heat shouldn't be nearly as much of an issue, now!"`
 				decline
 			label weaponcap
 			action
 				outfit "Weapons II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 37" "Chose weapon upgrade."
+				log Levels "Apoxys" "Level 37: Chose weapon upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Our projectiles will blot out the sun! Maybe even a couple suns."`
 				decline
 			label enginecap
 			action
 				outfit "Engines II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 37" "Chose engine upgrade."
+				log Levels "Apoxys" "Level 37: Chose engine upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Our engines will move us like a moth to a flame! Ideally without the burning alive part."`
 				decline
 			label cargocap
 			action
 				outfit "Cargo II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 37" "Chose cargo upgrade."
+				log Levels "Apoxys" "Level 37: Chose cargo upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. We'll be able to carry plenty of goodies now!"`
 				decline
 			label bunkcap
 			action
 				outfit "Bunks II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 37" "Chose bunk upgrade."
+				log Levels "Apoxys" "Level 37: Chose bunk upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. We'll have room for all sorts of friends!"`
 				decline
 
@@ -1757,42 +1757,42 @@ mission "Apoxys Level 38"
 			action
 				outfit "Outfit II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 38" "Chose outfit upgrade."
+				log Levels "Apoxys" "Level 38: Chose outfit upgrade."
 			`"More space sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label heatcap
 			action
 				outfit "Heat Capacity II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 38" "Chose heat capacity upgrade."
+				log Levels "Apoxys" "Level 38: Chose heat capacity upgrade."
 			`"More heat capacity sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label weaponcap
 			action
 				outfit "Weapons II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 38" "Chose weapon upgrade."
+				log Levels "Apoxys" "Level 38: Chose weapon upgrade."
 			`"More weaponry sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label enginecap
 			action
 				outfit "Engines II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 38" "Chose engine upgrade."
+				log Levels "Apoxys" "Level 38: Chose engine upgrade."
 			`"More engine capabilities sound good, captain!" Maribelle replies giddily.`
 				goto next
 			label cargocap
 			action
 				outfit "Cargo II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 38" "Chose cargo upgrade."
+				log Levels "Apoxys" "Level 38: Chose cargo upgrade."
 			`"More carrying capacity sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label bunkcap
 			action
 				outfit "Bunks II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 38" "Chose bunk upgrade."
+				log Levels "Apoxys" "Level 38: Chose bunk upgrade."
 			`"I'll be sure it's done, captain," Maribelle replies.`
 				goto next
 
@@ -1839,56 +1839,56 @@ mission "Apoxys Level 39"
 			action
 				outfit "Shields II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 39" "Chose shield upgrade."
+				log Levels "Apoxys" "Level 39: Chose shield upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Only the strongest shields to keep the bad things out!"`
 				decline
 			label hullcap
 			action
 				outfit "Hull II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 39" "Chose hull upgrade."
+				log Levels "Apoxys" "Level 39: Chose hull upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. The most durable hull, for resisting all that space throws at us!"`
 				decline
 			label outfitcap
 			action
 				outfit "Outfit II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 39" "Chose outfit upgrade."
+				log Levels "Apoxys" "Level 39: Chose outfit upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Just imagine what we can do with all the extra space!"`
 				decline
 			label heatcap
 			action
 				outfit "Heat Capacity II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 39" "Chose heat capacity upgrade."
+				log Levels "Apoxys" "Level 39: Chose heat capacity upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Heat shouldn't be nearly as much of an issue, now!"`
 				decline
 			label weaponcap
 			action
 				outfit "Weapons II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 39" "Chose weapon upgrade."
+				log Levels "Apoxys" "Level 39: Chose weapon upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Our projectiles will blot out the sun! Maybe even a couple suns."`
 				decline
 			label enginecap
 			action
 				outfit "Engines II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 39" "Chose engine upgrade."
+				log Levels "Apoxys" "Level 39: Chose engine upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Our engines will move us like a moth to a flame! Ideally without the burning alive part."`
 				decline
 			label cargocap
 			action
 				outfit "Cargo II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 39" "Chose cargo upgrade."
+				log Levels "Apoxys" "Level 39: Chose cargo upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. We'll be able to carry plenty of goodies now!"`
 				decline
 			label bunkcap
 			action
 				outfit "Bunks II" 1
 				outfit "Basal Level II" 1
-				log Levels "Level 39" "Chose bunk upgrade."
+				log Levels "Apoxys" "Level 39: Chose bunk upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. We'll have room for all sorts of friends!"`
 				decline
 
@@ -1931,56 +1931,56 @@ mission "Apoxys Level 40"
 			action
 				outfit "Shields II" 1
 				outfit "Milestone II" 1
-				log Levels "Level 40" "Chose shield upgrade."
+				log Levels "Apoxys" "Level 40: Chose shield upgrade."
 			`"I'll be sure to delegate some energy to that!" Maribelle says, still shaking excitedly.`
 				goto next
 			label hullcap
 			action
 				outfit "Hull II" 1
 				outfit "Milestone II" 1
-				log Levels "Level 40" "Chose hull upgrade."
+				log Levels "Apoxys" "Level 40: Chose hull upgrade."
 			`"I'll be sure to delegate some energy to that!" Maribelle says, still shaking excitedly.`
 				goto next
 			label outfitcap
 			action
 				outfit "Outfit II" 1
 				outfit "Milestone II" 1
-				log Levels "Level 40" "Chose outfit upgrade."
+				log Levels "Apoxys" "Level 40: Chose outfit upgrade."
 			`"I'll be sure to delegate some energy to that!" Maribelle says, still shaking excitedly.`
 				goto next
 			label heatcap
 			action
 				outfit "Heat Capacity II" 1
 				outfit "Milestone II" 1
-				log Levels "Level 40" "Chose heat capacity upgrade."
+				log Levels "Apoxys" "Level 40: Chose heat capacity upgrade."
 			`"I'll be sure to delegate some energy to that!" Maribelle says, still shaking excitedly.`
 				goto next
 			label weaponcap
 			action
 				outfit "Weapons II" 1
 				outfit "Milestone II" 1
-				log Levels "Level 40" "Chose weapon upgrade."
+				log Levels "Apoxys" "Level 40: Chose weapon upgrade."
 			`"I'll be sure to delegate some energy to that!" Maribelle says, still shaking excitedly.`
 				goto next
 			label enginecap
 			action
 				outfit "Engines II" 1
 				outfit "Milestone II" 1
-				log Levels "Level 40" "Chose engine upgrade."
+				log Levels "Apoxys" "Level 40: Chose engine upgrade."
 			`"I'll be sure to delegate some energy to that!" Maribelle says, still shaking excitedly.`
 				goto next
 			label cargocap
 			action
 				outfit "Cargo II" 1
 				outfit "Milestone II" 1
-				log Levels "Level 40" "Chose cargo upgrade."
+				log Levels "Apoxys" "Level 40: Chose cargo upgrade."
 			`"I'll be sure to delegate some energy to that!" Maribelle says, still shaking excitedly.`
 				goto next
 			label bunkcap
 			action
 				outfit "Bunks II" 1
 				outfit "Milestone II" 1
-				log Levels "Level 40" "Chose bunk upgrade."
+				log Levels "Apoxys" "Level 40: Chose bunk upgrade."
 			`"I'll be sure to delegate some energy to that!" Maribelle says, still shaking excitedly.`
 				goto next
 

--- a/data/apoxys/levels41-60.txt
+++ b/data/apoxys/levels41-60.txt
@@ -154,56 +154,56 @@ mission "Apoxys Level 41"
 			action
 				outfit "Shields III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 41" "Chose shield upgrade."
+				log Levels "Apoxys" "Level 41: Chose shield upgrade."
 			`"Oh!" Maribelle replies, seemingly a bit surprised that you cared to give your own input, "I'll do just that, then Captain. Only the strongest shields to keep the bad things out!"`
 				decline
 			label hullcap
 			action
 				outfit "Hull III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 41" "Chose hull upgrade."
+				log Levels "Apoxys" "Level 41: Chose hull upgrade."
 			`"Oh!" Maribelle replies, seemingly a bit surprised that you cared to give your own input, "I'll do just that, then Captain. The most durable hull, for resisting all that space throws at us!"`
 				decline
 			label outfitcap
 			action
 				outfit "Outfit III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 41" "Chose outfit upgrade."
+				log Levels "Apoxys" "Level 41: Chose outfit upgrade."
 			`"Oh!" Maribelle replies, seemingly a bit surprised that you cared to give your own input, "I'll do just that, then Captain. Just imagine what we can do with all the extra space!"`
 				decline
 			label heatcap
 			action
 				outfit "Heat Capacity III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 41" "Chose heat capacity upgrade."
+				log Levels "Apoxys" "Level 41: Chose heat capacity upgrade."
 			`"Oh!" Maribelle replies, seemingly a bit surprised that you cared to give your own input, "I'll do just that, then Captain. No heat will be too mighty for our heatsinks!"`
 				decline
 			label weaponcap
 			action
 				outfit "Weapons III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 41" "Chose weapon upgrade."
+				log Levels "Apoxys" "Level 41: Chose weapon upgrade."
 			`"Oh!" Maribelle replies, seemingly a bit surprised that you cared to give your own input, "I'll do just that, then Captain. Our projectiles will blot out the sun! Maybe even a couple suns."`
 				decline
 			label enginecap
 			action
 				outfit "Engines III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 41" "Chose engine upgrade."
+				log Levels "Apoxys" "Level 41: Chose engine upgrade."
 			`"Oh!" Maribelle replies, seemingly a bit surprised that you cared to give your own input, "I'll do just that, then Captain. Our engines will move us like a moth to a flame! Ideally without the burning alive part."`
 				decline
 			label cargocap
 			action
 				outfit "Cargo III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 41" "Chose cargo upgrade."
+				log Levels "Apoxys" "Level 41: Chose cargo upgrade."
 			`"Oh!" Maribelle replies, seemingly a bit surprised that you cared to give your own input, "I'll do just that, then Captain. We'll be able to carry plenty of goodies now!"`
 				decline
 			label bunkcap
 			action
 				outfit "Bunks III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 41" "Chose bunk upgrade."
+				log Levels "Apoxys" "Level 41: Chose bunk upgrade."
 			`"Oh!" Maribelle replies, seemingly a bit surprised that you cared to give your own input, "I'll do just that, then Captain. We'll have room for all sorts of friends!"`
 				decline
 
@@ -244,56 +244,56 @@ mission "Apoxys Level 42"
 			action
 				outfit "Shields III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 42" "Chose shield upgrade."
+				log Levels "Apoxys" "Level 42: Chose shield upgrade."
 			`"I'll be sure it's done, captain," Maribelle replies.`
 				goto next
 			label hullcap
 			action
 				outfit "Hull III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 42" "Chose hull upgrade."
+				log Levels "Apoxys" "Level 42: Chose hull upgrade."
 			`"I'll be sure it's done, captain," Maribelle replies.`
 				goto next
 			label outfitcap
 			action
 				outfit "Outfit III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 42" "Chose outfit upgrade."
+				log Levels "Apoxys" "Level 42: Chose outfit upgrade."
 			`"I'll be sure it's done, captain," Maribelle replies.`
 				goto next
 			label heatcap
 			action
 				outfit "Heat Capacity III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 42" "Chose heat capacity upgrade."
+				log Levels "Apoxys" "Level 42: Chose heat capacity upgrade."
 			`"I'll be sure it's done, captain," Maribelle replies.`
 				goto next
 			label weaponcap
 			action
 				outfit "Weapons III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 42" "Chose weapon upgrade."
+				log Levels "Apoxys" "Level 42: Chose weapon upgrade."
 			`"I'll be sure it's done, captain," Maribelle replies.`
 				goto next
 			label enginecap
 			action
 				outfit "Engines III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 42" "Chose engine upgrade."
+				log Levels "Apoxys" "Level 42: Chose engine upgrade."
 			`"I'll be sure it's done, captain," Maribelle replies.`
 				goto next
 			label cargocap
 			action
 				outfit "Cargo III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 42" "Chose cargo upgrade."
+				log Levels "Apoxys" "Level 42: Chose cargo upgrade."
 			`"I'll be sure it's done, captain," Maribelle replies.`
 				goto next
 			label bunkcap
 			action
 				outfit "Bunks III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 42" "Chose bunk upgrade."
+				log Levels "Apoxys" "Level 42: Chose bunk upgrade."
 			`"I'll be sure it's done, captain," Maribelle replies.`
 				goto next
 
@@ -341,56 +341,56 @@ mission "Apoxys Level 43"
 			action
 				outfit "Shields III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 43" "Chose shield upgrade."
+				log Levels "Apoxys" "Level 43: Chose shield upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Only the strongest shields to keep the bad things out!"`
 				decline
 			label hullcap
 			action
 				outfit "Hull III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 43" "Chose hull upgrade."
+				log Levels "Apoxys" "Level 43: Chose hull upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. The most durable hull, for resisting all that space throws at us!"`
 				decline
 			label outfitcap
 			action
 				outfit "Outfit III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 43" "Chose outfit upgrade."
+				log Levels "Apoxys" "Level 43: Chose outfit upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Just imagine what we can do with all the extra space!"`
 				decline
 			label heatcap
 			action
 				outfit "Heat Capacity III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 43" "Chose heat capacity upgrade."
+				log Levels "Apoxys" "Level 43: Chose heat capacity upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Heat shouldn't be nearly as much of an issue, now!"`
 				decline
 			label weaponcap
 			action
 				outfit "Weapons III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 43" "Chose weapon upgrade."
+				log Levels "Apoxys" "Level 43: Chose weapon upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Our projectiles will blot out the sun! Maybe even a couple suns."`
 				decline
 			label enginecap
 			action
 				outfit "Engines III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 43" "Chose engine upgrade."
+				log Levels "Apoxys" "Level 43: Chose engine upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Our engines will move us like a moth to a flame! Ideally without the burning alive part."`
 				decline
 			label cargocap
 			action
 				outfit "Cargo III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 43" "Chose cargo upgrade."
+				log Levels "Apoxys" "Level 43: Chose cargo upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. We'll be able to carry plenty of goodies now!"`
 				decline
 			label bunkcap
 			action
 				outfit "Bunks III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 43" "Chose bunk upgrade."
+				log Levels "Apoxys" "Level 43: Chose bunk upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. We'll have room for all sorts of friends!"`
 				decline
 
@@ -432,56 +432,56 @@ mission "Apoxys Level 44"
 			action
 				outfit "Shields III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 44" "Chose shield upgrade."
+				log Levels "Apoxys" "Level 44: Chose shield upgrade."
 			`"More shields sound good, captain!" Maribelle replies giddily.`
 				goto next
 			label hullcap
 			action
 				outfit "Hull III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 44" "Chose hull upgrade."
+				log Levels "Apoxys" "Level 44: Chose hull upgrade."
 			`"More hull sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label outfitcap
 			action
 				outfit "Outfit III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 44" "Chose outfit upgrade."
+				log Levels "Apoxys" "Level 44: Chose outfit upgrade."
 			`"More space sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label heatcap
 			action
 				outfit "Heat Capacity III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 44" "Chose heat capacity upgrade."
+				log Levels "Apoxys" "Level 44: Chose heat capacity upgrade."
 			`"More heat capacity sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label weaponcap
 			action
 				outfit "Weapons III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 44" "Chose weapon upgrade."
+				log Levels "Apoxys" "Level 44: Chose weapon upgrade."
 			`"More weaponry sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label enginecap
 			action
 				outfit "Engines III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 44" "Chose engine upgrade."
+				log Levels "Apoxys" "Level 44: Chose engine upgrade."
 			`"More engine capabilities sound good, captain!" Maribelle replies giddily.`
 				goto next
 			label cargocap
 			action
 				outfit "Cargo III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 44" "Chose cargo upgrade."
+				log Levels "Apoxys" "Level 44: Chose cargo upgrade."
 			`"More carrying capacity sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label bunkcap
 			action
 				outfit "Bunks III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 44" "Chose bunk upgrade."
+				log Levels "Apoxys" "Level 44: Chose bunk upgrade."
 			`"I'll be sure it's done, captain," Maribelle replies.`
 				goto next
 
@@ -528,56 +528,56 @@ mission "Apoxys Level 45"
 			action
 				outfit "Shields III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 45" "Chose shield upgrade."
+				log Levels "Apoxys" "Level 45: Chose shield upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Only the strongest shields to keep the bad things out!"`
 				decline
 			label hullcap
 			action
 				outfit "Hull III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 45" "Chose hull upgrade."
+				log Levels "Apoxys" "Level 45: Chose hull upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. The most durable hull, for resisting all that space throws at us!"`
 				decline
 			label outfitcap
 			action
 				outfit "Outfit III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 45" "Chose outfit upgrade."
+				log Levels "Apoxys" "Level 45: Chose outfit upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Just imagine what we can do with all the extra space!"`
 				decline
 			label heatcap
 			action
 				outfit "Heat Capacity III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 45" "Chose heat capacity upgrade."
+				log Levels "Apoxys" "Level 45: Chose heat capacity upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Heat shouldn't be nearly as much of an issue, now!"`
 				decline
 			label weaponcap
 			action
 				outfit "Weapons III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 45" "Chose weapon upgrade."
+				log Levels "Apoxys" "Level 45: Chose weapon upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Our projectiles will blot out the sun! Maybe even a couple suns."`
 				decline
 			label enginecap
 			action
 				outfit "Engines III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 45" "Chose engine upgrade."
+				log Levels "Apoxys" "Level 45: Chose engine upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Our engines will move us like a moth to a flame! Ideally without the burning alive part."`
 				decline
 			label cargocap
 			action
 				outfit "Cargo III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 45" "Chose cargo upgrade."
+				log Levels "Apoxys" "Level 45: Chose cargo upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. We'll be able to carry plenty of goodies now!"`
 				decline
 			label bunkcap
 			action
 				outfit "Bunks III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 45" "Chose bunk upgrade."
+				log Levels "Apoxys" "Level 45: Chose bunk upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. We'll have room for all sorts of friends!"`
 				decline
 
@@ -619,56 +619,56 @@ mission "Apoxys Level 46"
 			action
 				outfit "Shields III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 46" "Chose shield upgrade."
+				log Levels "Apoxys" "Level 46: Chose shield upgrade."
 			`"More shields sound good, captain!" Maribelle replies giddily.`
 				goto next
 			label hullcap
 			action
 				outfit "Hull III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 46" "Chose hull upgrade."
+				log Levels "Apoxys" "Level 46: Chose hull upgrade."
 			`"More hull sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label outfitcap
 			action
 				outfit "Outfit III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 46" "Chose outfit upgrade."
+				log Levels "Apoxys" "Level 46: Chose outfit upgrade."
 			`"More space sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label heatcap
 			action
 				outfit "Heat Capacity III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 46" "Chose heat capacity upgrade."
+				log Levels "Apoxys" "Level 46: Chose heat capacity upgrade."
 			`"More heat capacity sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label weaponcap
 			action
 				outfit "Weapons III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 46" "Chose weapon upgrade."
+				log Levels "Apoxys" "Level 46: Chose weapon upgrade."
 			`"More weaponry sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label enginecap
 			action
 				outfit "Engines III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 46" "Chose engine upgrade."
+				log Levels "Apoxys" "Level 46: Chose engine upgrade."
 			`"More engine capabilities sound good, captain!" Maribelle replies giddily.`
 				goto next
 			label cargocap
 			action
 				outfit "Cargo III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 46" "Chose cargo upgrade."
+				log Levels "Apoxys" "Level 46: Chose cargo upgrade."
 			`"More carrying capacity sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label bunkcap
 			action
 				outfit "Bunks III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 46" "Chose bunk upgrade."
+				log Levels "Apoxys" "Level 46: Chose bunk upgrade."
 			`"I'll be sure it's done, captain," Maribelle replies.`
 				goto next
 
@@ -715,56 +715,56 @@ mission "Apoxys Level 47"
 			action
 				outfit "Shields III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 47" "Chose shield upgrade."
+				log Levels "Apoxys" "Level 47: Chose shield upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Only the strongest shields to keep the bad things out!"`
 				decline
 			label hullcap
 			action
 				outfit "Hull III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 47" "Chose hull upgrade."
+				log Levels "Apoxys" "Level 47: Chose hull upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. The most durable hull, for resisting all that space throws at us!"`
 				decline
 			label outfitcap
 			action
 				outfit "Outfit III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 47" "Chose outfit upgrade."
+				log Levels "Apoxys" "Level 47: Chose outfit upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Just imagine what we can do with all the extra space!"`
 				decline
 			label heatcap
 			action
 				outfit "Heat Capacity III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 47" "Chose heat capacity upgrade."
+				log Levels "Apoxys" "Level 47: Chose heat capacity upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Heat shouldn't be nearly as much of an issue, now!"`
 				decline
 			label weaponcap
 			action
 				outfit "Weapons III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 47" "Chose weapon upgrade."
+				log Levels "Apoxys" "Level 47: Chose weapon upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Our projectiles will blot out the sun! Maybe even a couple suns."`
 				decline
 			label enginecap
 			action
 				outfit "Engines III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 47" "Chose engine upgrade."
+				log Levels "Apoxys" "Level 47: Chose engine upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Our engines will move us like a moth to a flame! Ideally without the burning alive part."`
 				decline
 			label cargocap
 			action
 				outfit "Cargo III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 47" "Chose cargo upgrade."
+				log Levels "Apoxys" "Level 47: Chose cargo upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. We'll be able to carry plenty of goodies now!"`
 				decline
 			label bunkcap
 			action
 				outfit "Bunks III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 47" "Chose bunk upgrade."
+				log Levels "Apoxys" "Level 47: Chose bunk upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. We'll have room for all sorts of friends!"`
 				decline
 
@@ -806,56 +806,56 @@ mission "Apoxys Level 48"
 			action
 				outfit "Shields III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 48" "Chose shield upgrade."
+				log Levels "Apoxys" "Level 48: Chose shield upgrade."
 			`"More shields sound good, captain!" Maribelle replies giddily.`
 				goto next
 			label hullcap
 			action
 				outfit "Hull III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 48" "Chose hull upgrade."
+				log Levels "Apoxys" "Level 48: Chose hull upgrade."
 			`"More hull sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label outfitcap
 			action
 				outfit "Outfit III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 48" "Chose outfit upgrade."
+				log Levels "Apoxys" "Level 48: Chose outfit upgrade."
 			`"More space sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label heatcap
 			action
 				outfit "Heat Capacity III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 48" "Chose heat capacity upgrade."
+				log Levels "Apoxys" "Level 48: Chose heat capacity upgrade."
 			`"More heat capacity sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label weaponcap
 			action
 				outfit "Weapons III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 48" "Chose weapon upgrade."
+				log Levels "Apoxys" "Level 48: Chose weapon upgrade."
 			`"More weaponry sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label enginecap
 			action
 				outfit "Engines III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 48" "Chose engine upgrade."
+				log Levels "Apoxys" "Level 48: Chose engine upgrade."
 			`"More engine capabilities sound good, captain!" Maribelle replies giddily.`
 				goto next
 			label cargocap
 			action
 				outfit "Cargo III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 48" "Chose cargo upgrade."
+				log Levels "Apoxys" "Level 48: Chose cargo upgrade."
 			`"More carrying capacity sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label bunkcap
 			action
 				outfit "Bunks III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 48" "Chose bunk upgrade."
+				log Levels "Apoxys" "Level 48: Chose bunk upgrade."
 			`"I'll be sure it's done, captain," Maribelle replies.`
 				goto next
 
@@ -902,56 +902,56 @@ mission "Apoxys Level 49"
 			action
 				outfit "Shields III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 49" "Chose shield upgrade."
+				log Levels "Apoxys" "Level 49: Chose shield upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Only the strongest shields to keep the bad things out!"`
 				decline
 			label hullcap
 			action
 				outfit "Hull III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 49" "Chose hull upgrade."
+				log Levels "Apoxys" "Level 49: Chose hull upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. The most durable hull, for resisting all that space throws at us!"`
 				decline
 			label outfitcap
 			action
 				outfit "Outfit III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 49" "Chose outfit upgrade."
+				log Levels "Apoxys" "Level 49: Chose outfit upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Just imagine what we can do with all the extra space!"`
 				decline
 			label heatcap
 			action
 				outfit "Heat Capacity III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 49" "Chose heat capacity upgrade."
+				log Levels "Apoxys" "Level 49: Chose heat capacity upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Heat shouldn't be nearly as much of an issue, now!"`
 				decline
 			label weaponcap
 			action
 				outfit "Weapons III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 49" "Chose weapon upgrade."
+				log Levels "Apoxys" "Level 49: Chose weapon upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Our projectiles will blot out the sun! Maybe even a couple suns."`
 				decline
 			label enginecap
 			action
 				outfit "Engines III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 49" "Chose engine upgrade."
+				log Levels "Apoxys" "Level 49: Chose engine upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Our engines will move us like a moth to a flame! Ideally without the burning alive part."`
 				decline
 			label cargocap
 			action
 				outfit "Cargo III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 49" "Chose cargo upgrade."
+				log Levels "Apoxys" "Level 49: Chose cargo upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. We'll be able to carry plenty of goodies now!"`
 				decline
 			label bunkcap
 			action
 				outfit "Bunks III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 49" "Chose bunk upgrade."
+				log Levels "Apoxys" "Level 49: Chose bunk upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. We'll have room for all sorts of friends!"`
 				decline
 
@@ -992,56 +992,56 @@ mission "Apoxys Level 50"
 			action
 				outfit "Shields III" 1
 				outfit "Milestone III" 1
-				log Levels "Level 50" "Chose shield upgrade."
+				log Levels "Apoxys" "Level 50: Chose shield upgrade."
 			`Maribelle nods. "I'll be sure to have it done," She says, "Now..."`
 				goto next
 			label hullcap
 			action
 				outfit "Hull III" 1
 				outfit "Milestone III" 1
-				log Levels "Level 50" "Chose hull upgrade."
+				log Levels "Apoxys" "Level 50: Chose hull upgrade."
 			`Maribelle nods. "I'll be sure to have it done," She says, "Now..."`
 				goto next
 			label outfitcap
 			action
 				outfit "Outfit III" 1
 				outfit "Milestone III" 1
-				log Levels "Level 50" "Chose outfit upgrade."
+				log Levels "Apoxys" "Level 50: Chose outfit upgrade."
 			`Maribelle nods. "I'll be sure to have it done," She says, "Now..."`
 				goto next
 			label heatcap
 			action
 				outfit "Heat Capacity III" 1
 				outfit "Milestone III" 1
-				log Levels "Level 50" "Chose heat capacity upgrade."
+				log Levels "Apoxys" "Level 50: Chose heat capacity upgrade."
 			`Maribelle nods. "I'll be sure to have it done," She says, "Now..."`
 				goto next
 			label weaponcap
 			action
 				outfit "Weapons III" 1
 				outfit "Milestone III" 1
-				log Levels "Level 50" "Chose weapon upgrade."
+				log Levels "Apoxys" "Level 50: Chose weapon upgrade."
 			`Maribelle nods. "I'll be sure to have it done," She says, "Now..."`
 				goto next
 			label enginecap
 			action
 				outfit "Engines III" 1
 				outfit "Milestone III" 1
-				log Levels "Level 50" "Chose engine upgrade."
+				log Levels "Apoxys" "Level 50: Chose engine upgrade."
 			`Maribelle nods. "I'll be sure to have it done," She says, "Now..."`
 				goto next
 			label cargocap
 			action
 				outfit "Cargo III" 1
 				outfit "Milestone III" 1
-				log Levels "Level 50" "Chose cargo upgrade."
+				log Levels "Apoxys" "Level 50: Chose cargo upgrade."
 			`Maribelle nods. "I'll be sure to have it done," She says, "Now..."`
 				goto next
 			label bunkcap
 			action
 				outfit "Bunks III" 1
 				outfit "Milestone III" 1
-				log Levels "Level 50" "Chose bunk upgrade."
+				log Levels "Apoxys" "Level 50: Chose bunk upgrade."
 			`Maribelle nods. "I'll be sure to have it done," She says, "Now..."`
 				goto next
 
@@ -1059,7 +1059,7 @@ mission "Apoxys Level 50"
 			label cloak
 			action
 				outfit "Perk: Cloaking Field" 1
-				log Levels "Level 50" "Chose Cloaking Field."
+				log Levels "Apoxys" "	Chose Cloaking Field."
 			`Maribelle looks at you. "Are you sure?" She asks.`
 			`	"Yes," You reply. "I'm certain."`
 			`	Maribelle forces a small smile. "Consider it done, then, captain."`
@@ -1068,7 +1068,7 @@ mission "Apoxys Level 50"
 			label spinal
 			action
 				outfit "Perk: Spinal Mount" 1
-				log Levels "Level 50" "Chose Spinal Mount."
+				log Levels "Apoxys" "	Chose Spinal Mount."
 			`Maribelle looks at you. "Are you sure?" She asks.`
 			`	"Yes," You reply. "I'm certain."`
 			`	Maribelle forces a small smile. "Consider it done, then, captain."`
@@ -1115,56 +1115,56 @@ mission "Apoxys Level 51"
 			action
 				outfit "Shields III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 51" "Chose shield upgrade."
+				log Levels "Apoxys" "Level 51: Chose shield upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Only the strongest shields to keep the bad things out!"`
 				decline
 			label hullcap
 			action
 				outfit "Hull III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 51" "Chose hull upgrade."
+				log Levels "Apoxys" "Level 51: Chose hull upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. The most durable hull, for resisting all that space throws at us!"`
 				decline
 			label outfitcap
 			action
 				outfit "Outfit III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 51" "Chose outfit upgrade."
+				log Levels "Apoxys" "Level 51: Chose outfit upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Just imagine what we can do with all the extra space!"`
 				decline
 			label heatcap
 			action
 				outfit "Heat Capacity III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 51" "Chose heat capacity upgrade."
+				log Levels "Apoxys" "Level 51: Chose heat capacity upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Heat shouldn't be nearly as much of an issue, now!"`
 				decline
 			label weaponcap
 			action
 				outfit "Weapons III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 51" "Chose weapon upgrade."
+				log Levels "Apoxys" "Level 51: Chose weapon upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Our projectiles will blot out the sun! Maybe even a couple suns."`
 				decline
 			label enginecap
 			action
 				outfit "Engines III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 51" "Chose engine upgrade."
+				log Levels "Apoxys" "Level 51: Chose engine upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Our engines will move us like a moth to a flame! Ideally without the burning alive part."`
 				decline
 			label cargocap
 			action
 				outfit "Cargo III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 51" "Chose cargo upgrade."
+				log Levels "Apoxys" "Level 51: Chose cargo upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. We'll be able to carry plenty of goodies now!"`
 				decline
 			label bunkcap
 			action
 				outfit "Bunks III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 51" "Chose bunk upgrade."
+				log Levels "Apoxys" "Level 51: Chose bunk upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. We'll have room for all sorts of friends!"`
 				decline
 
@@ -1206,56 +1206,56 @@ mission "Apoxys Level 52"
 			action
 				outfit "Shields III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 52" "Chose shield upgrade."
+				log Levels "Apoxys" "Level 52: Chose shield upgrade."
 			`"I'll be sure it's done, captain," Maribelle replies.`
 				goto next
 			label hullcap
 			action
 				outfit "Hull III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 52" "Chose hull upgrade."
+				log Levels "Apoxys" "Level 52: Chose hull upgrade."
 			`"I'll be sure it's done, captain," Maribelle replies.`
 				goto next
 			label outfitcap
 			action
 				outfit "Outfit III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 52" "Chose outfit upgrade."
+				log Levels "Apoxys" "Level 52: Chose outfit upgrade."
 			`"I'll be sure it's done, captain," Maribelle replies.`
 				goto next
 			label heatcap
 			action
 				outfit "Heat Capacity III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 52" "Chose heat capacity upgrade."
+				log Levels "Apoxys" "Level 52: Chose heat capacity upgrade."
 			`"I'll be sure it's done, captain," Maribelle replies.`
 				goto next
 			label weaponcap
 			action
 				outfit "Weapons III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 52" "Chose weapon upgrade."
+				log Levels "Apoxys" "Level 52: Chose weapon upgrade."
 			`"I'll be sure it's done, captain," Maribelle replies.`
 				goto next
 			label enginecap
 			action
 				outfit "Engines III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 52" "Chose engine upgrade."
+				log Levels "Apoxys" "Level 52: Chose engine upgrade."
 			`"I'll be sure it's done, captain," Maribelle replies.`
 				goto next
 			label cargocap
 			action
 				outfit "Cargo III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 52" "Chose cargo upgrade."
+				log Levels "Apoxys" "Level 52: Chose cargo upgrade."
 			`"I'll be sure it's done, captain," Maribelle replies.`
 				goto next
 			label bunkcap
 			action
 				outfit "Bunks III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 52" "Chose bunk upgrade."
+				log Levels "Apoxys" "Level 52: Chose bunk upgrade."
 			`"I'll be sure it's done, captain," Maribelle replies.`
 				goto next
 
@@ -1303,56 +1303,56 @@ mission "Apoxys Level 53"
 			action
 				outfit "Shields III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 53" "Chose shield upgrade."
+				log Levels "Apoxys" "Level 53: Chose shield upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Only the strongest shields to keep the bad things out!"`
 				decline
 			label hullcap
 			action
 				outfit "Hull III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 53" "Chose hull upgrade."
+				log Levels "Apoxys" "Level 53: Chose hull upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. The most durable hull, for resisting all that space throws at us!"`
 				decline
 			label outfitcap
 			action
 				outfit "Outfit III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 53" "Chose outfit upgrade."
+				log Levels "Apoxys" "Level 53: Chose outfit upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Just imagine what we can do with all the extra space!"`
 				decline
 			label heatcap
 			action
 				outfit "Heat Capacity III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 53" "Chose heat capacity upgrade."
+				log Levels "Apoxys" "Level 53: Chose heat capacity upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Heat shouldn't be nearly as much of an issue, now!"`
 				decline
 			label weaponcap
 			action
 				outfit "Weapons III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 53" "Chose weapon upgrade."
+				log Levels "Apoxys" "Level 53: Chose weapon upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Our projectiles will blot out the sun! Maybe even a couple suns."`
 				decline
 			label enginecap
 			action
 				outfit "Engines III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 53" "Chose engine upgrade."
+				log Levels "Apoxys" "Level 53: Chose engine upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Our engines will move us like a moth to a flame! Ideally without the burning alive part."`
 				decline
 			label cargocap
 			action
 				outfit "Cargo III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 53" "Chose cargo upgrade."
+				log Levels "Apoxys" "Level 53: Chose cargo upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. We'll be able to carry plenty of goodies now!"`
 				decline
 			label bunkcap
 			action
 				outfit "Bunks III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 53" "Chose bunk upgrade."
+				log Levels "Apoxys" "Level 53: Chose bunk upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. We'll have room for all sorts of friends!"`
 				decline
 
@@ -1394,56 +1394,56 @@ mission "Apoxys Level 54"
 			action
 				outfit "Shields III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 54" "Chose shield upgrade."
+				log Levels "Apoxys" "Level 54: Chose shield upgrade."
 			`"More shields sound good, captain!" Maribelle replies giddily.`
 				goto next
 			label hullcap
 			action
 				outfit "Hull III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 54" "Chose hull upgrade."
+				log Levels "Apoxys" "Level 54: Chose hull upgrade."
 			`"More hull sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label outfitcap
 			action
 				outfit "Outfit III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 54" "Chose outfit upgrade."
+				log Levels "Apoxys" "Level 54: Chose outfit upgrade."
 			`"More space sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label heatcap
 			action
 				outfit "Heat Capacity III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 54" "Chose heat capacity upgrade."
+				log Levels "Apoxys" "Level 54: Chose heat capacity upgrade."
 			`"More heat capacity sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label weaponcap
 			action
 				outfit "Weapons III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 54" "Chose weapon upgrade."
+				log Levels "Apoxys" "Level 54: Chose weapon upgrade."
 			`"More weaponry sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label enginecap
 			action
 				outfit "Engines III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 54" "Chose engine upgrade."
+				log Levels "Apoxys" "Level 54: Chose engine upgrade."
 			`"More engine capabilities sound good, captain!" Maribelle replies giddily.`
 				goto next
 			label cargocap
 			action
 				outfit "Cargo III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 54" "Chose cargo upgrade."
+				log Levels "Apoxys" "Level 54: Chose cargo upgrade."
 			`"More carrying capacity sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label bunkcap
 			action
 				outfit "Bunks III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 54" "Chose bunk upgrade."
+				log Levels "Apoxys" "Level 54: Chose bunk upgrade."
 			`"I'll be sure it's done, captain," Maribelle replies.`
 				goto next
 
@@ -1490,56 +1490,56 @@ mission "Apoxys Level 55"
 			action
 				outfit "Shields III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 55" "Chose shield upgrade."
+				log Levels "Apoxys" "Level 55: Chose shield upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Only the strongest shields to keep the bad things out!"`
 				decline
 			label hullcap
 			action
 				outfit "Hull III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 55" "Chose hull upgrade."
+				log Levels "Apoxys" "Level 55: Chose hull upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. The most durable hull, for resisting all that space throws at us!"`
 				decline
 			label outfitcap
 			action
 				outfit "Outfit III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 55" "Chose outfit upgrade."
+				log Levels "Apoxys" "Level 55: Chose outfit upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Just imagine what we can do with all the extra space!"`
 				decline
 			label heatcap
 			action
 				outfit "Heat Capacity III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 55" "Chose heat capacity upgrade."
+				log Levels "Apoxys" "Level 55: Chose heat capacity upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Heat shouldn't be nearly as much of an issue, now!"`
 				decline
 			label weaponcap
 			action
 				outfit "Weapons III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 55" "Chose weapon upgrade."
+				log Levels "Apoxys" "Level 55: Chose weapon upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Our projectiles will blot out the sun! Maybe even a couple suns."`
 				decline
 			label enginecap
 			action
 				outfit "Engines III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 55" "Chose engine upgrade."
+				log Levels "Apoxys" "Level 55: Chose engine upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Our engines will move us like a moth to a flame! Ideally without the burning alive part."`
 				decline
 			label cargocap
 			action
 				outfit "Cargo III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 55" "Chose cargo upgrade."
+				log Levels "Apoxys" "Level 55: Chose cargo upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. We'll be able to carry plenty of goodies now!"`
 				decline
 			label bunkcap
 			action
 				outfit "Bunks III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 55" "Chose bunk upgrade."
+				log Levels "Apoxys" "Level 55: Chose bunk upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. We'll have room for all sorts of friends!"`
 				decline
 
@@ -1581,56 +1581,56 @@ mission "Apoxys Level 56"
 			action
 				outfit "Shields III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 56" "Chose shield upgrade."
+				log Levels "Apoxys" "Level 56: Chose shield upgrade."
 			`"More shields sound good, captain!" Maribelle replies giddily.`
 				goto next
 			label hullcap
 			action
 				outfit "Hull III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 56" "Chose hull upgrade."
+				log Levels "Apoxys" "Level 56: Chose hull upgrade."
 			`"More hull sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label outfitcap
 			action
 				outfit "Outfit III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 56" "Chose outfit upgrade."
+				log Levels "Apoxys" "Level 56: Chose outfit upgrade."
 			`"More space sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label heatcap
 			action
 				outfit "Heat Capacity III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 56" "Chose heat capacity upgrade."
+				log Levels "Apoxys" "Level 56: Chose heat capacity upgrade."
 			`"More heat capacity sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label weaponcap
 			action
 				outfit "Weapons III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 56" "Chose weapon upgrade."
+				log Levels "Apoxys" "Level 56: Chose weapon upgrade."
 			`"More weaponry sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label enginecap
 			action
 				outfit "Engines III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 56" "Chose engine upgrade."
+				log Levels "Apoxys" "Level 56: Chose engine upgrade."
 			`"More engine capabilities sound good, captain!" Maribelle replies giddily.`
 				goto next
 			label cargocap
 			action
 				outfit "Cargo III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 56" "Chose cargo upgrade."
+				log Levels "Apoxys" "Level 56: Chose cargo upgrade."
 			`"More carrying capacity sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label bunkcap
 			action
 				outfit "Bunks III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 56" "Chose bunk upgrade."
+				log Levels "Apoxys" "Level 56: Chose bunk upgrade."
 			`"I'll be sure it's done, captain," Maribelle replies.`
 				goto next
 
@@ -1677,56 +1677,56 @@ mission "Apoxys Level 57"
 			action
 				outfit "Shields III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 57" "Chose shield upgrade."
+				log Levels "Apoxys" "Level 57: Chose shield upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Only the strongest shields to keep the bad things out!"`
 				decline
 			label hullcap
 			action
 				outfit "Hull III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 57" "Chose hull upgrade."
+				log Levels "Apoxys" "Level 57: Chose hull upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. The most durable hull, for resisting all that space throws at us!"`
 				decline
 			label outfitcap
 			action
 				outfit "Outfit III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 57" "Chose outfit upgrade."
+				log Levels "Apoxys" "Level 57: Chose outfit upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Just imagine what we can do with all the extra space!"`
 				decline
 			label heatcap
 			action
 				outfit "Heat Capacity III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 57" "Chose heat capacity upgrade."
+				log Levels "Apoxys" "Level 57: Chose heat capacity upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Heat shouldn't be nearly as much of an issue, now!"`
 				decline
 			label weaponcap
 			action
 				outfit "Weapons III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 57" "Chose weapon upgrade."
+				log Levels "Apoxys" "Level 57: Chose weapon upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Our projectiles will blot out the sun! Maybe even a couple suns."`
 				decline
 			label enginecap
 			action
 				outfit "Engines III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 57" "Chose engine upgrade."
+				log Levels "Apoxys" "Level 57: Chose engine upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Our engines will move us like a moth to a flame! Ideally without the burning alive part."`
 				decline
 			label cargocap
 			action
 				outfit "Cargo III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 57" "Chose cargo upgrade."
+				log Levels "Apoxys" "Level 57: Chose cargo upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. We'll be able to carry plenty of goodies now!"`
 				decline
 			label bunkcap
 			action
 				outfit "Bunks III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 57" "Chose bunk upgrade."
+				log Levels "Apoxys" "Level 57: Chose bunk upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. We'll have room for all sorts of friends!"`
 				decline
 
@@ -1782,42 +1782,42 @@ mission "Apoxys Level 58"
 			action
 				outfit "Outfit III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 58" "Chose outfit upgrade."
+				log Levels "Apoxys" "Level 58: Chose outfit upgrade."
 			`"More space sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label heatcap
 			action
 				outfit "Heat Capacity III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 58" "Chose heat capacity upgrade."
+				log Levels "Apoxys" "Level 58: Chose heat capacity upgrade."
 			`"More heat capacity sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label weaponcap
 			action
 				outfit "Weapons III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 58" "Chose weapon upgrade."
+				log Levels "Apoxys" "Level 58: Chose weapon upgrade."
 			`"More weaponry sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label enginecap
 			action
 				outfit "Engines III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 58" "Chose engine upgrade."
+				log Levels "Apoxys" "Level 58: Chose engine upgrade."
 			`"More engine capabilities sound good, captain!" Maribelle replies giddily.`
 				goto next
 			label cargocap
 			action
 				outfit "Cargo III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 58" "Chose cargo upgrade."
+				log Levels "Apoxys" "Level 58: Chose cargo upgrade."
 			`"More carrying capacity sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label bunkcap
 			action
 				outfit "Bunks III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 58" "Chose bunk upgrade."
+				log Levels "Apoxys" "Level 58: Chose bunk upgrade."
 			`"I'll be sure it's done, captain," Maribelle replies.`
 				goto next
 
@@ -1864,56 +1864,56 @@ mission "Apoxys Level 59"
 			action
 				outfit "Shields III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 59" "Chose shield upgrade."
+				log Levels "Apoxys" "Level 59: Chose shield upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Only the strongest shields to keep the bad things out!"`
 				decline
 			label hullcap
 			action
 				outfit "Hull III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 59" "Chose hull upgrade."
+				log Levels "Apoxys" "Level 59: Chose hull upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. The most durable hull, for resisting all that space throws at us!"`
 				decline
 			label outfitcap
 			action
 				outfit "Outfit III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 59" "Chose outfit upgrade."
+				log Levels "Apoxys" "Level 59: Chose outfit upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Just imagine what we can do with all the extra space!"`
 				decline
 			label heatcap
 			action
 				outfit "Heat Capacity III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 59" "Chose heat capacity upgrade."
+				log Levels "Apoxys" "Level 59: Chose heat capacity upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Heat shouldn't be nearly as much of an issue, now!"`
 				decline
 			label weaponcap
 			action
 				outfit "Weapons III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 59" "Chose weapon upgrade."
+				log Levels "Apoxys" "Level 59: Chose weapon upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Our projectiles will blot out the sun! Maybe even a couple suns."`
 				decline
 			label enginecap
 			action
 				outfit "Engines III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 59" "Chose engine upgrade."
+				log Levels "Apoxys" "Level 59: Chose engine upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Our engines will move us like a moth to a flame! Ideally without the burning alive part."`
 				decline
 			label cargocap
 			action
 				outfit "Cargo III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 59" "Chose cargo upgrade."
+				log Levels "Apoxys" "Level 59: Chose cargo upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. We'll be able to carry plenty of goodies now!"`
 				decline
 			label bunkcap
 			action
 				outfit "Bunks III" 1
 				outfit "Basal Level III" 1
-				log Levels "Level 59" "Chose bunk upgrade."
+				log Levels "Apoxys" "Level 59: Chose bunk upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. We'll have room for all sorts of friends!"`
 				decline
 
@@ -1956,56 +1956,56 @@ mission "Apoxys Level 60"
 			action
 				outfit "Shields III" 1
 				outfit "Milestone III" 1
-				log Levels "Level 60" "Chose shield upgrade."
+				log Levels "Apoxys" "Level 60: Chose shield upgrade."
 			`"I'll be sure to delegate some energy to that!" Maribelle says, still shaking excitedly.`
 				goto next
 			label hullcap
 			action
 				outfit "Hull III" 1
 				outfit "Milestone III" 1
-				log Levels "Level 60" "Chose hull upgrade."
+				log Levels "Apoxys" "Level 60: Chose hull upgrade."
 			`"I'll be sure to delegate some energy to that!" Maribelle says, still shaking excitedly.`
 				goto next
 			label outfitcap
 			action
 				outfit "Outfit III" 1
 				outfit "Milestone III" 1
-				log Levels "Level 60" "Chose outfit upgrade."
+				log Levels "Apoxys" "Level 60: Chose outfit upgrade."
 			`"I'll be sure to delegate some energy to that!" Maribelle says, still shaking excitedly.`
 				goto next
 			label heatcap
 			action
 				outfit "Heat Capacity III" 1
 				outfit "Milestone III" 1
-				log Levels "Level 60" "Chose heat capacity upgrade."
+				log Levels "Apoxys" "Level 60: Chose heat capacity upgrade."
 			`"I'll be sure to delegate some energy to that!" Maribelle says, still shaking excitedly.`
 				goto next
 			label weaponcap
 			action
 				outfit "Weapons III" 1
 				outfit "Milestone III" 1
-				log Levels "Level 60" "Chose weapon upgrade."
+				log Levels "Apoxys" "Level 60: Chose weapon upgrade."
 			`"I'll be sure to delegate some energy to that!" Maribelle says, still shaking excitedly.`
 				goto next
 			label enginecap
 			action
 				outfit "Engines III" 1
 				outfit "Milestone III" 1
-				log Levels "Level 60" "Chose engine upgrade."
+				log Levels "Apoxys" "Level 60: Chose engine upgrade."
 			`"I'll be sure to delegate some energy to that!" Maribelle says, still shaking excitedly.`
 				goto next
 			label cargocap
 			action
 				outfit "Cargo III" 1
 				outfit "Milestone III" 1
-				log Levels "Level 60" "Chose cargo upgrade."
+				log Levels "Apoxys" "Level 60: Chose cargo upgrade."
 			`"I'll be sure to delegate some energy to that!" Maribelle says, still shaking excitedly.`
 				goto next
 			label bunkcap
 			action
 				outfit "Bunks III" 1
 				outfit "Milestone III" 1
-				log Levels "Level 60" "Chose bunk upgrade."
+				log Levels "Apoxys" "Level 60: Chose bunk upgrade."
 			`"I'll be sure to delegate some energy to that!" Maribelle says, still shaking excitedly.`
 				goto next
 

--- a/data/apoxys/levels61-80.txt
+++ b/data/apoxys/levels61-80.txt
@@ -154,56 +154,56 @@ mission "Apoxys Level 61"
 			action
 				outfit "Shields IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 61" "Chose shield upgrade."
+				log Levels "Apoxys" "Level 61: Chose shield upgrade."
 			`"Oh!" Maribelle replies, seemingly a bit surprised that you cared to give your own input, "I'll do just that, then Captain. Only the strongest shields to keep the bad things out!"`
 				decline
 			label hullcap
 			action
 				outfit "Hull IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 61" "Chose hull upgrade."
+				log Levels "Apoxys" "Level 61: Chose hull upgrade."
 			`"Oh!" Maribelle replies, seemingly a bit surprised that you cared to give your own input, "I'll do just that, then Captain. The most durable hull, for resisting all that space throws at us!"`
 				decline
 			label outfitcap
 			action
 				outfit "Outfit IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 61" "Chose outfit upgrade."
+				log Levels "Apoxys" "Level 61: Chose outfit upgrade."
 			`"Oh!" Maribelle replies, seemingly a bit surprised that you cared to give your own input, "I'll do just that, then Captain. Just imagine what we can do with all the extra space!"`
 				decline
 			label heatcap
 			action
 				outfit "Heat Capacity IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 61" "Chose heat capacity upgrade."
+				log Levels "Apoxys" "Level 61: Chose heat capacity upgrade."
 			`"Oh!" Maribelle replies, seemingly a bit surprised that you cared to give your own input, "I'll do just that, then Captain. No heat will be too mighty for our heatsinks!"`
 				decline
 			label weaponcap
 			action
 				outfit "Weapons IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 61" "Chose weapon upgrade."
+				log Levels "Apoxys" "Level 61: Chose weapon upgrade."
 			`"Oh!" Maribelle replies, seemingly a bit surprised that you cared to give your own input, "I'll do just that, then Captain. Our projectiles will blot out the sun! Maybe even a couple suns."`
 				decline
 			label enginecap
 			action
 				outfit "Engines IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 61" "Chose engine upgrade."
+				log Levels "Apoxys" "Level 61: Chose engine upgrade."
 			`"Oh!" Maribelle replies, seemingly a bit surprised that you cared to give your own input, "I'll do just that, then Captain. Our engines will move us like a moth to a flame! Ideally without the burning alive part."`
 				decline
 			label cargocap
 			action
 				outfit "Cargo IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 61" "Chose cargo upgrade."
+				log Levels "Apoxys" "Level 61: Chose cargo upgrade."
 			`"Oh!" Maribelle replies, seemingly a bit surprised that you cared to give your own input, "I'll do just that, then Captain. We'll be able to carry plenty of goodies now!"`
 				decline
 			label bunkcap
 			action
 				outfit "Bunks IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 61" "Chose bunk upgrade."
+				log Levels "Apoxys" "Level 61: Chose bunk upgrade."
 			`"Oh!" Maribelle replies, seemingly a bit surprised that you cared to give your own input, "I'll do just that, then Captain. We'll have room for all sorts of friends!"`
 				decline
 
@@ -244,56 +244,56 @@ mission "Apoxys Level 62"
 			action
 				outfit "Shields IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 62" "Chose shield upgrade."
+				log Levels "Apoxys" "Level 62: Chose shield upgrade."
 			`"I'll be sure it's done, captain," Maribelle replies.`
 				goto next
 			label hullcap
 			action
 				outfit "Hull IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 62" "Chose hull upgrade."
+				log Levels "Apoxys" "Level 62: Chose hull upgrade."
 			`"I'll be sure it's done, captain," Maribelle replies.`
 				goto next
 			label outfitcap
 			action
 				outfit "Outfit IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 62" "Chose outfit upgrade."
+				log Levels "Apoxys" "Level 62: Chose outfit upgrade."
 			`"I'll be sure it's done, captain," Maribelle replies.`
 				goto next
 			label heatcap
 			action
 				outfit "Heat Capacity IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 62" "Chose heat capacity upgrade."
+				log Levels "Apoxys" "Level 62: Chose heat capacity upgrade."
 			`"I'll be sure it's done, captain," Maribelle replies.`
 				goto next
 			label weaponcap
 			action
 				outfit "Weapons IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 62" "Chose weapon upgrade."
+				log Levels "Apoxys" "Level 62: Chose weapon upgrade."
 			`"I'll be sure it's done, captain," Maribelle replies.`
 				goto next
 			label enginecap
 			action
 				outfit "Engines IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 62" "Chose engine upgrade."
+				log Levels "Apoxys" "Level 62: Chose engine upgrade."
 			`"I'll be sure it's done, captain," Maribelle replies.`
 				goto next
 			label cargocap
 			action
 				outfit "Cargo IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 62" "Chose cargo upgrade."
+				log Levels "Apoxys" "Level 62: Chose cargo upgrade."
 			`"I'll be sure it's done, captain," Maribelle replies.`
 				goto next
 			label bunkcap
 			action
 				outfit "Bunks IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 62" "Chose bunk upgrade."
+				log Levels "Apoxys" "Level 62: Chose bunk upgrade."
 			`"I'll be sure it's done, captain," Maribelle replies.`
 				goto next
 
@@ -341,56 +341,56 @@ mission "Apoxys Level 63"
 			action
 				outfit "Shields IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 63" "Chose shield upgrade."
+				log Levels "Apoxys" "Level 63: Chose shield upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Only the strongest shields to keep the bad things out!"`
 				decline
 			label hullcap
 			action
 				outfit "Hull IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 63" "Chose hull upgrade."
+				log Levels "Apoxys" "Level 63: Chose hull upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. The most durable hull, for resisting all that space throws at us!"`
 				decline
 			label outfitcap
 			action
 				outfit "Outfit IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 63" "Chose outfit upgrade."
+				log Levels "Apoxys" "Level 63: Chose outfit upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Just imagine what we can do with all the extra space!"`
 				decline
 			label heatcap
 			action
 				outfit "Heat Capacity IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 63" "Chose heat capacity upgrade."
+				log Levels "Apoxys" "Level 63: Chose heat capacity upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Heat shouldn't be nearly as much of an issue, now!"`
 				decline
 			label weaponcap
 			action
 				outfit "Weapons IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 63" "Chose weapon upgrade."
+				log Levels "Apoxys" "Level 63: Chose weapon upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Our projectiles will blot out the sun! Maybe even a couple suns."`
 				decline
 			label enginecap
 			action
 				outfit "Engines IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 63" "Chose engine upgrade."
+				log Levels "Apoxys" "Level 63: Chose engine upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Our engines will move us like a moth to a flame! Ideally without the burning alive part."`
 				decline
 			label cargocap
 			action
 				outfit "Cargo IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 63" "Chose cargo upgrade."
+				log Levels "Apoxys" "Level 63: Chose cargo upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. We'll be able to carry plenty of goodies now!"`
 				decline
 			label bunkcap
 			action
 				outfit "Bunks IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 63" "Chose bunk upgrade."
+				log Levels "Apoxys" "Level 63: Chose bunk upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. We'll have room for all sorts of friends!"`
 				decline
 
@@ -432,56 +432,56 @@ mission "Apoxys Level 64"
 			action
 				outfit "Shields IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 64" "Chose shield upgrade."
+				log Levels "Apoxys" "Level 64: Chose shield upgrade."
 			`"More shields sound good, captain!" Maribelle replies giddily.`
 				goto next
 			label hullcap
 			action
 				outfit "Hull IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 64" "Chose hull upgrade."
+				log Levels "Apoxys" "Level 64: Chose hull upgrade."
 			`"More hull sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label outfitcap
 			action
 				outfit "Outfit IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 64" "Chose outfit upgrade."
+				log Levels "Apoxys" "Level 64: Chose outfit upgrade."
 			`"More space sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label heatcap
 			action
 				outfit "Heat Capacity IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 64" "Chose heat capacity upgrade."
+				log Levels "Apoxys" "Level 64: Chose heat capacity upgrade."
 			`"More heat capacity sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label weaponcap
 			action
 				outfit "Weapons IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 64" "Chose weapon upgrade."
+				log Levels "Apoxys" "Level 64: Chose weapon upgrade."
 			`"More weaponry sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label enginecap
 			action
 				outfit "Engines IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 64" "Chose engine upgrade."
+				log Levels "Apoxys" "Level 64: Chose engine upgrade."
 			`"More engine capabilities sound good, captain!" Maribelle replies giddily.`
 				goto next
 			label cargocap
 			action
 				outfit "Cargo IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 64" "Chose cargo upgrade."
+				log Levels "Apoxys" "Level 64: Chose cargo upgrade."
 			`"More carrying capacity sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label bunkcap
 			action
 				outfit "Bunks IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 64" "Chose bunk upgrade."
+				log Levels "Apoxys" "Level 64: Chose bunk upgrade."
 			`"I'll be sure it's done, captain," Maribelle replies.`
 				goto next
 
@@ -528,56 +528,56 @@ mission "Apoxys Level 65"
 			action
 				outfit "Shields IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 65" "Chose shield upgrade."
+				log Levels "Apoxys" "Level 65: Chose shield upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Only the strongest shields to keep the bad things out!"`
 				decline
 			label hullcap
 			action
 				outfit "Hull IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 65" "Chose hull upgrade."
+				log Levels "Apoxys" "Level 65: Chose hull upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. The most durable hull, for resisting all that space throws at us!"`
 				decline
 			label outfitcap
 			action
 				outfit "Outfit IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 65" "Chose outfit upgrade."
+				log Levels "Apoxys" "Level 65: Chose outfit upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Just imagine what we can do with all the extra space!"`
 				decline
 			label heatcap
 			action
 				outfit "Heat Capacity IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 65" "Chose heat capacity upgrade."
+				log Levels "Apoxys" "Level 65: Chose heat capacity upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Heat shouldn't be nearly as much of an issue, now!"`
 				decline
 			label weaponcap
 			action
 				outfit "Weapons IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 65" "Chose weapon upgrade."
+				log Levels "Apoxys" "Level 65: Chose weapon upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Our projectiles will blot out the sun! Maybe even a couple suns."`
 				decline
 			label enginecap
 			action
 				outfit "Engines IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 65" "Chose engine upgrade."
+				log Levels "Apoxys" "Level 65: Chose engine upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Our engines will move us like a moth to a flame! Ideally without the burning alive part."`
 				decline
 			label cargocap
 			action
 				outfit "Cargo IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 65" "Chose cargo upgrade."
+				log Levels "Apoxys" "Level 65: Chose cargo upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. We'll be able to carry plenty of goodies now!"`
 				decline
 			label bunkcap
 			action
 				outfit "Bunks IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 65" "Chose bunk upgrade."
+				log Levels "Apoxys" "Level 65: Chose bunk upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. We'll have room for all sorts of friends!"`
 				decline
 
@@ -619,56 +619,56 @@ mission "Apoxys Level 66"
 			action
 				outfit "Shields IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 66" "Chose shield upgrade."
+				log Levels "Apoxys" "Level 66: Chose shield upgrade."
 			`"More shields sound good, captain!" Maribelle replies giddily.`
 				goto next
 			label hullcap
 			action
 				outfit "Hull IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 66" "Chose hull upgrade."
+				log Levels "Apoxys" "Level 66: Chose hull upgrade."
 			`"More hull sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label outfitcap
 			action
 				outfit "Outfit IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 66" "Chose outfit upgrade."
+				log Levels "Apoxys" "Level 66: Chose outfit upgrade."
 			`"More space sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label heatcap
 			action
 				outfit "Heat Capacity IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 66" "Chose heat capacity upgrade."
+				log Levels "Apoxys" "Level 66: Chose heat capacity upgrade."
 			`"More heat capacity sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label weaponcap
 			action
 				outfit "Weapons IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 66" "Chose weapon upgrade."
+				log Levels "Apoxys" "Level 66: Chose weapon upgrade."
 			`"More weaponry sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label enginecap
 			action
 				outfit "Engines IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 66" "Chose engine upgrade."
+				log Levels "Apoxys" "Level 66: Chose engine upgrade."
 			`"More engine capabilities sound good, captain!" Maribelle replies giddily.`
 				goto next
 			label cargocap
 			action
 				outfit "Cargo IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 66" "Chose cargo upgrade."
+				log Levels "Apoxys" "Level 66: Chose cargo upgrade."
 			`"More carrying capacity sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label bunkcap
 			action
 				outfit "Bunks IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 66" "Chose bunk upgrade."
+				log Levels "Apoxys" "Level 66: Chose bunk upgrade."
 			`"I'll be sure it's done, captain," Maribelle replies.`
 				goto next
 
@@ -715,56 +715,56 @@ mission "Apoxys Level 67"
 			action
 				outfit "Shields IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 67" "Chose shield upgrade."
+				log Levels "Apoxys" "Level 67: Chose shield upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Only the strongest shields to keep the bad things out!"`
 				decline
 			label hullcap
 			action
 				outfit "Hull IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 67" "Chose hull upgrade."
+				log Levels "Apoxys" "Level 67: Chose hull upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. The most durable hull, for resisting all that space throws at us!"`
 				decline
 			label outfitcap
 			action
 				outfit "Outfit IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 67" "Chose outfit upgrade."
+				log Levels "Apoxys" "Level 67: Chose outfit upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Just imagine what we can do with all the extra space!"`
 				decline
 			label heatcap
 			action
 				outfit "Heat Capacity IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 67" "Chose heat capacity upgrade."
+				log Levels "Apoxys" "Level 67: Chose heat capacity upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Heat shouldn't be nearly as much of an issue, now!"`
 				decline
 			label weaponcap
 			action
 				outfit "Weapons IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 67" "Chose weapon upgrade."
+				log Levels "Apoxys" "Level 67: Chose weapon upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Our projectiles will blot out the sun! Maybe even a couple suns."`
 				decline
 			label enginecap
 			action
 				outfit "Engines IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 67" "Chose engine upgrade."
+				log Levels "Apoxys" "Level 67: Chose engine upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Our engines will move us like a moth to a flame! Ideally without the burning alive part."`
 				decline
 			label cargocap
 			action
 				outfit "Cargo IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 67" "Chose cargo upgrade."
+				log Levels "Apoxys" "Level 67: Chose cargo upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. We'll be able to carry plenty of goodies now!"`
 				decline
 			label bunkcap
 			action
 				outfit "Bunks IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 67" "Chose bunk upgrade."
+				log Levels "Apoxys" "Level 67: Chose bunk upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. We'll have room for all sorts of friends!"`
 				decline
 
@@ -806,56 +806,56 @@ mission "Apoxys Level 68"
 			action
 				outfit "Shields IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 68" "Chose shield upgrade."
+				log Levels "Apoxys" "Level 68: Chose shield upgrade."
 			`"More shields sound good, captain!" Maribelle replies giddily.`
 				goto next
 			label hullcap
 			action
 				outfit "Hull IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 68" "Chose hull upgrade."
+				log Levels "Apoxys" "Level 68: Chose hull upgrade."
 			`"More hull sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label outfitcap
 			action
 				outfit "Outfit IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 68" "Chose outfit upgrade."
+				log Levels "Apoxys" "Level 68: Chose outfit upgrade."
 			`"More space sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label heatcap
 			action
 				outfit "Heat Capacity IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 68" "Chose heat capacity upgrade."
+				log Levels "Apoxys" "Level 68: Chose heat capacity upgrade."
 			`"More heat capacity sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label weaponcap
 			action
 				outfit "Weapons IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 68" "Chose weapon upgrade."
+				log Levels "Apoxys" "Level 68: Chose weapon upgrade."
 			`"More weaponry sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label enginecap
 			action
 				outfit "Engines IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 68" "Chose engine upgrade."
+				log Levels "Apoxys" "Level 68: Chose engine upgrade."
 			`"More engine capabilities sound good, captain!" Maribelle replies giddily.`
 				goto next
 			label cargocap
 			action
 				outfit "Cargo IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 68" "Chose cargo upgrade."
+				log Levels "Apoxys" "Level 68: Chose cargo upgrade."
 			`"More carrying capacity sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label bunkcap
 			action
 				outfit "Bunks IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 68" "Chose bunk upgrade."
+				log Levels "Apoxys" "Level 68: Chose bunk upgrade."
 			`"I'll be sure it's done, captain," Maribelle replies.`
 				goto next
 
@@ -902,56 +902,56 @@ mission "Apoxys Level 69"
 			action
 				outfit "Shields IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 69" "Chose shield upgrade."
+				log Levels "Apoxys" "Level 69: Chose shield upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Only the strongest shields to keep the bad things out!"`
 				decline
 			label hullcap
 			action
 				outfit "Hull IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 69" "Chose hull upgrade."
+				log Levels "Apoxys" "Level 69: Chose hull upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. The most durable hull, for resisting all that space throws at us!"`
 				decline
 			label outfitcap
 			action
 				outfit "Outfit IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 69" "Chose outfit upgrade."
+				log Levels "Apoxys" "Level 69: Chose outfit upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Just imagine what we can do with all the extra space!"`
 				decline
 			label heatcap
 			action
 				outfit "Heat Capacity IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 69" "Chose heat capacity upgrade."
+				log Levels "Apoxys" "Level 69: Chose heat capacity upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Heat shouldn't be nearly as much of an issue, now!"`
 				decline
 			label weaponcap
 			action
 				outfit "Weapons IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 69" "Chose weapon upgrade."
+				log Levels "Apoxys" "Level 69: Chose weapon upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Our projectiles will blot out the sun! Maybe even a couple suns."`
 				decline
 			label enginecap
 			action
 				outfit "Engines IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 69" "Chose engine upgrade."
+				log Levels "Apoxys" "Level 69: Chose engine upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Our engines will move us like a moth to a flame! Ideally without the burning alive part."`
 				decline
 			label cargocap
 			action
 				outfit "Cargo IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 69" "Chose cargo upgrade."
+				log Levels "Apoxys" "Level 69: Chose cargo upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. We'll be able to carry plenty of goodies now!"`
 				decline
 			label bunkcap
 			action
 				outfit "Bunks IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 69" "Chose bunk upgrade."
+				log Levels "Apoxys" "Level 69: Chose bunk upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. We'll have room for all sorts of friends!"`
 				decline
 
@@ -992,56 +992,56 @@ mission "Apoxys Level 70"
 			action
 				outfit "Shields IV" 1
 				outfit "Milestone IV" 1
-				log Levels "Level 70" "Chose shield upgrade."
+				log Levels "Apoxys" "Level 70: Chose shield upgrade."
 			`Maribelle nods. "I'll be sure to have it done," She says, "Now..."`
 				goto next
 			label hullcap
 			action
 				outfit "Hull IV" 1
 				outfit "Milestone IV" 1
-				log Levels "Level 70" "Chose hull upgrade."
+				log Levels "Apoxys" "Level 70: Chose hull upgrade."
 			`Maribelle nods. "I'll be sure to have it done," She says, "Now..."`
 				goto next
 			label outfitcap
 			action
 				outfit "Outfit IV" 1
 				outfit "Milestone IV" 1
-				log Levels "Level 70" "Chose outfit upgrade."
+				log Levels "Apoxys" "Level 70: Chose outfit upgrade."
 			`Maribelle nods. "I'll be sure to have it done," She says, "Now..."`
 				goto next
 			label heatcap
 			action
 				outfit "Heat Capacity IV" 1
 				outfit "Milestone IV" 1
-				log Levels "Level 70" "Chose heat capacity upgrade."
+				log Levels "Apoxys" "Level 70: Chose heat capacity upgrade."
 			`Maribelle nods. "I'll be sure to have it done," She says, "Now..."`
 				goto next
 			label weaponcap
 			action
 				outfit "Weapons IV" 1
 				outfit "Milestone IV" 1
-				log Levels "Level 70" "Chose weapon upgrade."
+				log Levels "Apoxys" "Level 70: Chose weapon upgrade."
 			`Maribelle nods. "I'll be sure to have it done," She says, "Now..."`
 				goto next
 			label enginecap
 			action
 				outfit "Engines IV" 1
 				outfit "Milestone IV" 1
-				log Levels "Level 70" "Chose engine upgrade."
+				log Levels "Apoxys" "Level 70: Chose engine upgrade."
 			`Maribelle nods. "I'll be sure to have it done," She says, "Now..."`
 				goto next
 			label cargocap
 			action
 				outfit "Cargo IV" 1
 				outfit "Milestone IV" 1
-				log Levels "Level 70" "Chose cargo upgrade."
+				log Levels "Apoxys" "Level 70: Chose cargo upgrade."
 			`Maribelle nods. "I'll be sure to have it done," She says, "Now..."`
 				goto next
 			label bunkcap
 			action
 				outfit "Bunks IV" 1
 				outfit "Milestone IV" 1
-				log Levels "Level 70" "Chose bunk upgrade."
+				log Levels "Apoxys" "Level 70: Chose bunk upgrade."
 			`Maribelle nods. "I'll be sure to have it done," She says, "Now..."`
 				goto next
 
@@ -1088,56 +1088,56 @@ mission "Apoxys Level 71"
 			action
 				outfit "Shields IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 71" "Chose shield upgrade."
+				log Levels "Apoxys" "Level 71: Chose shield upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Only the strongest shields to keep the bad things out!"`
 				decline
 			label hullcap
 			action
 				outfit "Hull IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 71" "Chose hull upgrade."
+				log Levels "Apoxys" "Level 71: Chose hull upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. The most durable hull, for resisting all that space throws at us!"`
 				decline
 			label outfitcap
 			action
 				outfit "Outfit IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 71" "Chose outfit upgrade."
+				log Levels "Apoxys" "Level 71: Chose outfit upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Just imagine what we can do with all the extra space!"`
 				decline
 			label heatcap
 			action
 				outfit "Heat Capacity IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 71" "Chose heat capacity upgrade."
+				log Levels "Apoxys" "Level 71: Chose heat capacity upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Heat shouldn't be nearly as much of an issue, now!"`
 				decline
 			label weaponcap
 			action
 				outfit "Weapons IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 71" "Chose weapon upgrade."
+				log Levels "Apoxys" "Level 71: Chose weapon upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Our projectiles will blot out the sun! Maybe even a couple suns."`
 				decline
 			label enginecap
 			action
 				outfit "Engines IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 71" "Chose engine upgrade."
+				log Levels "Apoxys" "Level 71: Chose engine upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Our engines will move us like a moth to a flame! Ideally without the burning alive part."`
 				decline
 			label cargocap
 			action
 				outfit "Cargo IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 71" "Chose cargo upgrade."
+				log Levels "Apoxys" "Level 71: Chose cargo upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. We'll be able to carry plenty of goodies now!"`
 				decline
 			label bunkcap
 			action
 				outfit "Bunks IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 71" "Chose bunk upgrade."
+				log Levels "Apoxys" "Level 71: Chose bunk upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. We'll have room for all sorts of friends!"`
 				decline
 
@@ -1179,56 +1179,56 @@ mission "Apoxys Level 72"
 			action
 				outfit "Shields IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 72" "Chose shield upgrade."
+				log Levels "Apoxys" "Level 72: Chose shield upgrade."
 			`"I'll be sure it's done, captain," Maribelle replies.`
 				goto next
 			label hullcap
 			action
 				outfit "Hull IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 72" "Chose hull upgrade."
+				log Levels "Apoxys" "Level 72: Chose hull upgrade."
 			`"I'll be sure it's done, captain," Maribelle replies.`
 				goto next
 			label outfitcap
 			action
 				outfit "Outfit IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 72" "Chose outfit upgrade."
+				log Levels "Apoxys" "Level 72: Chose outfit upgrade."
 			`"I'll be sure it's done, captain," Maribelle replies.`
 				goto next
 			label heatcap
 			action
 				outfit "Heat Capacity IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 72" "Chose heat capacity upgrade."
+				log Levels "Apoxys" "Level 72: Chose heat capacity upgrade."
 			`"I'll be sure it's done, captain," Maribelle replies.`
 				goto next
 			label weaponcap
 			action
 				outfit "Weapons IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 72" "Chose weapon upgrade."
+				log Levels "Apoxys" "Level 72: Chose weapon upgrade."
 			`"I'll be sure it's done, captain," Maribelle replies.`
 				goto next
 			label enginecap
 			action
 				outfit "Engines IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 72" "Chose engine upgrade."
+				log Levels "Apoxys" "Level 72: Chose engine upgrade."
 			`"I'll be sure it's done, captain," Maribelle replies.`
 				goto next
 			label cargocap
 			action
 				outfit "Cargo IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 72" "Chose cargo upgrade."
+				log Levels "Apoxys" "Level 72: Chose cargo upgrade."
 			`"I'll be sure it's done, captain," Maribelle replies.`
 				goto next
 			label bunkcap
 			action
 				outfit "Bunks IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 72" "Chose bunk upgrade."
+				log Levels "Apoxys" "Level 72: Chose bunk upgrade."
 			`"I'll be sure it's done, captain," Maribelle replies.`
 				goto next
 
@@ -1276,56 +1276,56 @@ mission "Apoxys Level 73"
 			action
 				outfit "Shields IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 73" "Chose shield upgrade."
+				log Levels "Apoxys" "Level 73: Chose shield upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Only the strongest shields to keep the bad things out!"`
 				decline
 			label hullcap
 			action
 				outfit "Hull IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 73" "Chose hull upgrade."
+				log Levels "Apoxys" "Level 73: Chose hull upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. The most durable hull, for resisting all that space throws at us!"`
 				decline
 			label outfitcap
 			action
 				outfit "Outfit IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 73" "Chose outfit upgrade."
+				log Levels "Apoxys" "Level 73: Chose outfit upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Just imagine what we can do with all the extra space!"`
 				decline
 			label heatcap
 			action
 				outfit "Heat Capacity IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 73" "Chose heat capacity upgrade."
+				log Levels "Apoxys" "Level 73: Chose heat capacity upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Heat shouldn't be nearly as much of an issue, now!"`
 				decline
 			label weaponcap
 			action
 				outfit "Weapons IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 73" "Chose weapon upgrade."
+				log Levels "Apoxys" "Level 73: Chose weapon upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Our projectiles will blot out the sun! Maybe even a couple suns."`
 				decline
 			label enginecap
 			action
 				outfit "Engines IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 73" "Chose engine upgrade."
+				log Levels "Apoxys" "Level 73: Chose engine upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Our engines will move us like a moth to a flame! Ideally without the burning alive part."`
 				decline
 			label cargocap
 			action
 				outfit "Cargo IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 73" "Chose cargo upgrade."
+				log Levels "Apoxys" "Level 73: Chose cargo upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. We'll be able to carry plenty of goodies now!"`
 				decline
 			label bunkcap
 			action
 				outfit "Bunks IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 73" "Chose bunk upgrade."
+				log Levels "Apoxys" "Level 73: Chose bunk upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. We'll have room for all sorts of friends!"`
 				decline
 
@@ -1367,56 +1367,56 @@ mission "Apoxys Level 74"
 			action
 				outfit "Shields IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 74" "Chose shield upgrade."
+				log Levels "Apoxys" "Level 74: Chose shield upgrade."
 			`"More shields sound good, captain!" Maribelle replies giddily.`
 				goto next
 			label hullcap
 			action
 				outfit "Hull IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 74" "Chose hull upgrade."
+				log Levels "Apoxys" "Level 74: Chose hull upgrade."
 			`"More hull sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label outfitcap
 			action
 				outfit "Outfit IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 74" "Chose outfit upgrade."
+				log Levels "Apoxys" "Level 74: Chose outfit upgrade."
 			`"More space sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label heatcap
 			action
 				outfit "Heat Capacity IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 74" "Chose heat capacity upgrade."
+				log Levels "Apoxys" "Level 74: Chose heat capacity upgrade."
 			`"More heat capacity sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label weaponcap
 			action
 				outfit "Weapons IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 74" "Chose weapon upgrade."
+				log Levels "Apoxys" "Level 74: Chose weapon upgrade."
 			`"More weaponry sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label enginecap
 			action
 				outfit "Engines IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 74" "Chose engine upgrade."
+				log Levels "Apoxys" "Level 74: Chose engine upgrade."
 			`"More engine capabilities sound good, captain!" Maribelle replies giddily.`
 				goto next
 			label cargocap
 			action
 				outfit "Cargo IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 74" "Chose cargo upgrade."
+				log Levels "Apoxys" "Level 74: Chose cargo upgrade."
 			`"More carrying capacity sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label bunkcap
 			action
 				outfit "Bunks IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 74" "Chose bunk upgrade."
+				log Levels "Apoxys" "Level 74: Chose bunk upgrade."
 			`"I'll be sure it's done, captain," Maribelle replies.`
 				goto next
 
@@ -1463,56 +1463,56 @@ mission "Apoxys Level 75"
 			action
 				outfit "Shields IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 75" "Chose shield upgrade."
+				log Levels "Apoxys" "Level 75: Chose shield upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Only the strongest shields to keep the bad things out!"`
 				decline
 			label hullcap
 			action
 				outfit "Hull IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 75" "Chose hull upgrade."
+				log Levels "Apoxys" "Level 75: Chose hull upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. The most durable hull, for resisting all that space throws at us!"`
 				decline
 			label outfitcap
 			action
 				outfit "Outfit IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 75" "Chose outfit upgrade."
+				log Levels "Apoxys" "Level 75: Chose outfit upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Just imagine what we can do with all the extra space!"`
 				decline
 			label heatcap
 			action
 				outfit "Heat Capacity IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 75" "Chose heat capacity upgrade."
+				log Levels "Apoxys" "Level 75: Chose heat capacity upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Heat shouldn't be nearly as much of an issue, now!"`
 				decline
 			label weaponcap
 			action
 				outfit "Weapons IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 75" "Chose weapon upgrade."
+				log Levels "Apoxys" "Level 75: Chose weapon upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Our projectiles will blot out the sun! Maybe even a couple suns."`
 				decline
 			label enginecap
 			action
 				outfit "Engines IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 75" "Chose engine upgrade."
+				log Levels "Apoxys" "Level 75: Chose engine upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Our engines will move us like a moth to a flame! Ideally without the burning alive part."`
 				decline
 			label cargocap
 			action
 				outfit "Cargo IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 75" "Chose cargo upgrade."
+				log Levels "Apoxys" "Level 75: Chose cargo upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. We'll be able to carry plenty of goodies now!"`
 				decline
 			label bunkcap
 			action
 				outfit "Bunks IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 75" "Chose bunk upgrade."
+				log Levels "Apoxys" "Level 75: Chose bunk upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. We'll have room for all sorts of friends!"`
 				decline
 
@@ -1554,56 +1554,56 @@ mission "Apoxys Level 76"
 			action
 				outfit "Shields IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 76" "Chose shield upgrade."
+				log Levels "Apoxys" "Level 76: Chose shield upgrade."
 			`"More shields sound good, captain!" Maribelle replies giddily.`
 				goto next
 			label hullcap
 			action
 				outfit "Hull IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 76" "Chose hull upgrade."
+				log Levels "Apoxys" "Level 76: Chose hull upgrade."
 			`"More hull sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label outfitcap
 			action
 				outfit "Outfit IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 76" "Chose outfit upgrade."
+				log Levels "Apoxys" "Level 76: Chose outfit upgrade."
 			`"More space sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label heatcap
 			action
 				outfit "Heat Capacity IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 76" "Chose heat capacity upgrade."
+				log Levels "Apoxys" "Level 76: Chose heat capacity upgrade."
 			`"More heat capacity sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label weaponcap
 			action
 				outfit "Weapons IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 76" "Chose weapon upgrade."
+				log Levels "Apoxys" "Level 76: Chose weapon upgrade."
 			`"More weaponry sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label enginecap
 			action
 				outfit "Engines IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 76" "Chose engine upgrade."
+				log Levels "Apoxys" "Level 76: Chose engine upgrade."
 			`"More engine capabilities sound good, captain!" Maribelle replies giddily.`
 				goto next
 			label cargocap
 			action
 				outfit "Cargo IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 76" "Chose cargo upgrade."
+				log Levels "Apoxys" "Level 76: Chose cargo upgrade."
 			`"More carrying capacity sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label bunkcap
 			action
 				outfit "Bunks IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 76" "Chose bunk upgrade."
+				log Levels "Apoxys" "Level 76: Chose bunk upgrade."
 			`"I'll be sure it's done, captain," Maribelle replies.`
 				goto next
 
@@ -1650,56 +1650,56 @@ mission "Apoxys Level 77"
 			action
 				outfit "Shields IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 77" "Chose shield upgrade."
+				log Levels "Apoxys" "Level 77: Chose shield upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Only the strongest shields to keep the bad things out!"`
 				decline
 			label hullcap
 			action
 				outfit "Hull IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 77" "Chose hull upgrade."
+				log Levels "Apoxys" "Level 77: Chose hull upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. The most durable hull, for resisting all that space throws at us!"`
 				decline
 			label outfitcap
 			action
 				outfit "Outfit IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 77" "Chose outfit upgrade."
+				log Levels "Apoxys" "Level 77: Chose outfit upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Just imagine what we can do with all the extra space!"`
 				decline
 			label heatcap
 			action
 				outfit "Heat Capacity IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 77" "Chose heat capacity upgrade."
+				log Levels "Apoxys" "Level 77: Chose heat capacity upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Heat shouldn't be nearly as much of an issue, now!"`
 				decline
 			label weaponcap
 			action
 				outfit "Weapons IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 77" "Chose weapon upgrade."
+				log Levels "Apoxys" "Level 77: Chose weapon upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Our projectiles will blot out the sun! Maybe even a couple suns."`
 				decline
 			label enginecap
 			action
 				outfit "Engines IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 77" "Chose engine upgrade."
+				log Levels "Apoxys" "Level 77: Chose engine upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Our engines will move us like a moth to a flame! Ideally without the burning alive part."`
 				decline
 			label cargocap
 			action
 				outfit "Cargo IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 77" "Chose cargo upgrade."
+				log Levels "Apoxys" "Level 77: Chose cargo upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. We'll be able to carry plenty of goodies now!"`
 				decline
 			label bunkcap
 			action
 				outfit "Bunks IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 77" "Chose bunk upgrade."
+				log Levels "Apoxys" "Level 77: Chose bunk upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. We'll have room for all sorts of friends!"`
 				decline
 
@@ -1755,42 +1755,42 @@ mission "Apoxys Level 78"
 			action
 				outfit "Outfit IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 78" "Chose outfit upgrade."
+				log Levels "Apoxys" "Level 78: Chose outfit upgrade."
 			`"More space sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label heatcap
 			action
 				outfit "Heat Capacity IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 78" "Chose heat capacity upgrade."
+				log Levels "Apoxys" "Level 78: Chose heat capacity upgrade."
 			`"More heat capacity sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label weaponcap
 			action
 				outfit "Weapons IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 78" "Chose weapon upgrade."
+				log Levels "Apoxys" "Level 78: Chose weapon upgrade."
 			`"More weaponry sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label enginecap
 			action
 				outfit "Engines IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 78" "Chose engine upgrade."
+				log Levels "Apoxys" "Level 78: Chose engine upgrade."
 			`"More engine capabilities sound good, captain!" Maribelle replies giddily.`
 				goto next
 			label cargocap
 			action
 				outfit "Cargo IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 78" "Chose cargo upgrade."
+				log Levels "Apoxys" "Level 78: Chose cargo upgrade."
 			`"More carrying capacity sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label bunkcap
 			action
 				outfit "Bunks IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 78" "Chose bunk upgrade."
+				log Levels "Apoxys" "Level 78: Chose bunk upgrade."
 			`"I'll be sure it's done, captain," Maribelle replies.`
 				goto next
 
@@ -1837,56 +1837,56 @@ mission "Apoxys Level 79"
 			action
 				outfit "Shields IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 79" "Chose shield upgrade."
+				log Levels "Apoxys" "Level 79: Chose shield upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Only the strongest shields to keep the bad things out!"`
 				decline
 			label hullcap
 			action
 				outfit "Hull IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 79" "Chose hull upgrade."
+				log Levels "Apoxys" "Level 79: Chose hull upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. The most durable hull, for resisting all that space throws at us!"`
 				decline
 			label outfitcap
 			action
 				outfit "Outfit IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 79" "Chose outfit upgrade."
+				log Levels "Apoxys" "Level 79: Chose outfit upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Just imagine what we can do with all the extra space!"`
 				decline
 			label heatcap
 			action
 				outfit "Heat Capacity IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 79" "Chose heat capacity upgrade."
+				log Levels "Apoxys" "Level 79: Chose heat capacity upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Heat shouldn't be nearly as much of an issue, now!"`
 				decline
 			label weaponcap
 			action
 				outfit "Weapons IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 79" "Chose weapon upgrade."
+				log Levels "Apoxys" "Level 79: Chose weapon upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Our projectiles will blot out the sun! Maybe even a couple suns."`
 				decline
 			label enginecap
 			action
 				outfit "Engines IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 79" "Chose engine upgrade."
+				log Levels "Apoxys" "Level 79: Chose engine upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Our engines will move us like a moth to a flame! Ideally without the burning alive part."`
 				decline
 			label cargocap
 			action
 				outfit "Cargo IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 79" "Chose cargo upgrade."
+				log Levels "Apoxys" "Level 79: Chose cargo upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. We'll be able to carry plenty of goodies now!"`
 				decline
 			label bunkcap
 			action
 				outfit "Bunks IV" 1
 				outfit "Basal Level IV" 1
-				log Levels "Level 79" "Chose bunk upgrade."
+				log Levels "Apoxys" "Level 79: Chose bunk upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. We'll have room for all sorts of friends!"`
 				decline
 
@@ -1929,21 +1929,21 @@ mission "Apoxys Level 80"
 			action
 				outfit "Shields IV" 1
 				outfit "Milestone IV" 1
-				log Levels "Level 80" "Chose shield upgrade."
+				log Levels "Apoxys" "Level 80: Chose shield upgrade."
 			`"I'll be sure to delegate some energy to that!" Maribelle says, still shaking excitedly.`
 				goto next
 			label hullcap
 			action
 				outfit "Hull IV" 1
 				outfit "Milestone IV" 1
-				log Levels "Level 80" "Chose hull upgrade."
+				log Levels "Apoxys" "Level 80: Chose hull upgrade."
 			`"I'll be sure to delegate some energy to that!" Maribelle says, still shaking excitedly.`
 				goto next
 			label outfitcap
 			action
 				outfit "Outfit IV" 1
 				outfit "Milestone IV" 1
-				log Levels "Level 80" "Chose outfit upgrade."
+				log Levels "Apoxys" "Level 80: Chose outfit upgrade."
 			`"I'll be sure to delegate some energy to that!" Maribelle says, still shaking excitedly.`
 				goto next
 			label heatcap
@@ -1957,28 +1957,28 @@ mission "Apoxys Level 80"
 			action
 				outfit "Weapons IV" 1
 				outfit "Milestone IV" 1
-				log Levels "Level 80" "Chose weapon upgrade."
+				log Levels "Apoxys" "Level 80: Chose weapon upgrade."
 			`"I'll be sure to delegate some energy to that!" Maribelle says, still shaking excitedly.`
 				goto next
 			label enginecap
 			action
 				outfit "Engines IV" 1
 				outfit "Milestone IV" 1
-				log Levels "Level 80" "Chose engine upgrade."
+				log Levels "Apoxys" "Level 80: Chose engine upgrade."
 			`"I'll be sure to delegate some energy to that!" Maribelle says, still shaking excitedly.`
 				goto next
 			label cargocap
 			action
 				outfit "Cargo IV" 1
 				outfit "Milestone IV" 1
-				log Levels "Level 80" "Chose cargo upgrade."
+				log Levels "Apoxys" "Level 80: Chose cargo upgrade."
 			`"I'll be sure to delegate some energy to that!" Maribelle says, still shaking excitedly.`
 				goto next
 			label bunkcap
 			action
 				outfit "Bunks IV" 1
 				outfit "Milestone IV" 1
-				log Levels "Level 80" "Chose bunk upgrade."
+				log Levels "Apoxys" "Level 80: Chose bunk upgrade."
 			`"I'll be sure to delegate some energy to that!" Maribelle says, still shaking excitedly.`
 				goto next
 

--- a/data/apoxys/levels81-100.txt
+++ b/data/apoxys/levels81-100.txt
@@ -154,56 +154,56 @@ mission "Apoxys Level 81"
 			action
 				outfit "Shields V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 81" "Chose shield upgrade."
+				log Levels "Apoxys" "Level 81: Chose shield upgrade."
 			`"Oh!" Maribelle replies, seemingly a bit surprised that you cared to give your own input, "I'll do just that, then Captain. Only the strongest shields to keep the bad things out!"`
 				decline
 			label hullcap
 			action
 				outfit "Hull V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 81" "Chose hull upgrade."
+				log Levels "Apoxys" "Level 81: Chose hull upgrade."
 			`"Oh!" Maribelle replies, seemingly a bit surprised that you cared to give your own input, "I'll do just that, then Captain. The most durable hull, for resisting all that space throws at us!"`
 				decline
 			label outfitcap
 			action
 				outfit "Outfit V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 81" "Chose outfit upgrade."
+				log Levels "Apoxys" "Level 81: Chose outfit upgrade."
 			`"Oh!" Maribelle replies, seemingly a bit surprised that you cared to give your own input, "I'll do just that, then Captain. Just imagine what we can do with all the extra space!"`
 				decline
 			label heatcap
 			action
 				outfit "Heat Capacity V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 81" "Chose heat capacity upgrade."
+				log Levels "Apoxys" "Level 81: Chose heat capacity upgrade."
 			`"Oh!" Maribelle replies, seemingly a bit surprised that you cared to give your own input, "I'll do just that, then Captain. No heat will be too mighty for our heatsinks!"`
 				decline
 			label weaponcap
 			action
 				outfit "Weapons V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 81" "Chose weapon upgrade."
+				log Levels "Apoxys" "Level 81: Chose weapon upgrade."
 			`"Oh!" Maribelle replies, seemingly a bit surprised that you cared to give your own input, "I'll do just that, then Captain. Our projectiles will blot out the sun! Maybe even a couple suns."`
 				decline
 			label enginecap
 			action
 				outfit "Engines V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 81" "Chose engine upgrade."
+				log Levels "Apoxys" "Level 81: Chose engine upgrade."
 			`"Oh!" Maribelle replies, seemingly a bit surprised that you cared to give your own input, "I'll do just that, then Captain. Our engines will move us like a moth to a flame! Ideally without the burning alive part."`
 				decline
 			label cargocap
 			action
 				outfit "Cargo V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 81" "Chose cargo upgrade."
+				log Levels "Apoxys" "Level 81: Chose cargo upgrade."
 			`"Oh!" Maribelle replies, seemingly a bit surprised that you cared to give your own input, "I'll do just that, then Captain. We'll be able to carry plenty of goodies now!"`
 				decline
 			label bunkcap
 			action
 				outfit "Bunks V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 81" "Chose bunk upgrade."
+				log Levels "Apoxys" "Level 81: Chose bunk upgrade."
 			`"Oh!" Maribelle replies, seemingly a bit surprised that you cared to give your own input, "I'll do just that, then Captain. We'll have room for all sorts of friends!"`
 				decline
 
@@ -244,56 +244,56 @@ mission "Apoxys Level 82"
 			action
 				outfit "Shields V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 82" "Chose shield upgrade."
+				log Levels "Apoxys" "Level 82: Chose shield upgrade."
 			`"I'll be sure it's done, captain," Maribelle replies.`
 				goto next
 			label hullcap
 			action
 				outfit "Hull V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 82" "Chose hull upgrade."
+				log Levels "Apoxys" "Level 82: Chose hull upgrade."
 			`"I'll be sure it's done, captain," Maribelle replies.`
 				goto next
 			label outfitcap
 			action
 				outfit "Outfit V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 82" "Chose outfit upgrade."
+				log Levels "Apoxys" "Level 82: Chose outfit upgrade."
 			`"I'll be sure it's done, captain," Maribelle replies.`
 				goto next
 			label heatcap
 			action
 				outfit "Heat Capacity V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 82" "Chose heat capacity upgrade."
+				log Levels "Apoxys" "Level 82: Chose heat capacity upgrade."
 			`"I'll be sure it's done, captain," Maribelle replies.`
 				goto next
 			label weaponcap
 			action
 				outfit "Weapons V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 82" "Chose weapon upgrade."
+				log Levels "Apoxys" "Level 82: Chose weapon upgrade."
 			`"I'll be sure it's done, captain," Maribelle replies.`
 				goto next
 			label enginecap
 			action
 				outfit "Engines V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 82" "Chose engine upgrade."
+				log Levels "Apoxys" "Level 82: Chose engine upgrade."
 			`"I'll be sure it's done, captain," Maribelle replies.`
 				goto next
 			label cargocap
 			action
 				outfit "Cargo V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 82" "Chose cargo upgrade."
+				log Levels "Apoxys" "Level 82: Chose cargo upgrade."
 			`"I'll be sure it's done, captain," Maribelle replies.`
 				goto next
 			label bunkcap
 			action
 				outfit "Bunks V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 82" "Chose bunk upgrade."
+				log Levels "Apoxys" "Level 82: Chose bunk upgrade."
 			`"I'll be sure it's done, captain," Maribelle replies.`
 				goto next
 
@@ -341,56 +341,56 @@ mission "Apoxys Level 83"
 			action
 				outfit "Shields V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 83" "Chose shield upgrade."
+				log Levels "Apoxys" "Level 83: Chose shield upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Only the strongest shields to keep the bad things out!"`
 				decline
 			label hullcap
 			action
 				outfit "Hull V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 83" "Chose hull upgrade."
+				log Levels "Apoxys" "Level 83: Chose hull upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. The most durable hull, for resisting all that space throws at us!"`
 				decline
 			label outfitcap
 			action
 				outfit "Outfit V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 83" "Chose outfit upgrade."
+				log Levels "Apoxys" "Level 83: Chose outfit upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Just imagine what we can do with all the extra space!"`
 				decline
 			label heatcap
 			action
 				outfit "Heat Capacity V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 83" "Chose heat capacity upgrade."
+				log Levels "Apoxys" "Level 83: Chose heat capacity upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Heat shouldn't be nearly as much of an issue, now!"`
 				decline
 			label weaponcap
 			action
 				outfit "Weapons V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 83" "Chose weapon upgrade."
+				log Levels "Apoxys" "Level 83: Chose weapon upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Our projectiles will blot out the sun! Maybe even a couple suns."`
 				decline
 			label enginecap
 			action
 				outfit "Engines V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 83" "Chose engine upgrade."
+				log Levels "Apoxys" "Level 83: Chose engine upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Our engines will move us like a moth to a flame! Ideally without the burning alive part."`
 				decline
 			label cargocap
 			action
 				outfit "Cargo V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 83" "Chose cargo upgrade."
+				log Levels "Apoxys" "Level 83: Chose cargo upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. We'll be able to carry plenty of goodies now!"`
 				decline
 			label bunkcap
 			action
 				outfit "Bunks V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 83" "Chose bunk upgrade."
+				log Levels "Apoxys" "Level 83: Chose bunk upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. We'll have room for all sorts of friends!"`
 				decline
 
@@ -432,56 +432,56 @@ mission "Apoxys Level 84"
 			action
 				outfit "Shields V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 84" "Chose shield upgrade."
+				log Levels "Apoxys" "Level 84: Chose shield upgrade."
 			`"More shields sound good, captain!" Maribelle replies giddily.`
 				goto next
 			label hullcap
 			action
 				outfit "Hull V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 84" "Chose hull upgrade."
+				log Levels "Apoxys" "Level 84: Chose hull upgrade."
 			`"More hull sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label outfitcap
 			action
 				outfit "Outfit V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 84" "Chose outfit upgrade."
+				log Levels "Apoxys" "Level 84: Chose outfit upgrade."
 			`"More space sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label heatcap
 			action
 				outfit "Heat Capacity V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 84" "Chose heat capacity upgrade."
+				log Levels "Apoxys" "Level 84: Chose heat capacity upgrade."
 			`"More heat capacity sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label weaponcap
 			action
 				outfit "Weapons V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 84" "Chose weapon upgrade."
+				log Levels "Apoxys" "Level 84: Chose weapon upgrade."
 			`"More weaponry sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label enginecap
 			action
 				outfit "Engines V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 84" "Chose engine upgrade."
+				log Levels "Apoxys" "Level 84: Chose engine upgrade."
 			`"More engine capabilities sound good, captain!" Maribelle replies giddily.`
 				goto next
 			label cargocap
 			action
 				outfit "Cargo V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 84" "Chose cargo upgrade."
+				log Levels "Apoxys" "Level 84: Chose cargo upgrade."
 			`"More carrying capacity sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label bunkcap
 			action
 				outfit "Bunks V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 84" "Chose bunk upgrade."
+				log Levels "Apoxys" "Level 84: Chose bunk upgrade."
 			`"I'll be sure it's done, captain," Maribelle replies.`
 				goto next
 
@@ -528,56 +528,56 @@ mission "Apoxys Level 85"
 			action
 				outfit "Shields V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 85" "Chose shield upgrade."
+				log Levels "Apoxys" "Level 85: Chose shield upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Only the strongest shields to keep the bad things out!"`
 				decline
 			label hullcap
 			action
 				outfit "Hull V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 85" "Chose hull upgrade."
+				log Levels "Apoxys" "Level 85: Chose hull upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. The most durable hull, for resisting all that space throws at us!"`
 				decline
 			label outfitcap
 			action
 				outfit "Outfit V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 85" "Chose outfit upgrade."
+				log Levels "Apoxys" "Level 85: Chose outfit upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Just imagine what we can do with all the extra space!"`
 				decline
 			label heatcap
 			action
 				outfit "Heat Capacity V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 85" "Chose heat capacity upgrade."
+				log Levels "Apoxys" "Level 85: Chose heat capacity upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Heat shouldn't be nearly as much of an issue, now!"`
 				decline
 			label weaponcap
 			action
 				outfit "Weapons V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 85" "Chose weapon upgrade."
+				log Levels "Apoxys" "Level 85: Chose weapon upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Our projectiles will blot out the sun! Maybe even a couple suns."`
 				decline
 			label enginecap
 			action
 				outfit "Engines V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 85" "Chose engine upgrade."
+				log Levels "Apoxys" "Level 85: Chose engine upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Our engines will move us like a moth to a flame! Ideally without the burning alive part."`
 				decline
 			label cargocap
 			action
 				outfit "Cargo V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 85" "Chose cargo upgrade."
+				log Levels "Apoxys" "Level 85: Chose cargo upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. We'll be able to carry plenty of goodies now!"`
 				decline
 			label bunkcap
 			action
 				outfit "Bunks V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 85" "Chose bunk upgrade."
+				log Levels "Apoxys" "Level 85: Chose bunk upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. We'll have room for all sorts of friends!"`
 				decline
 
@@ -619,56 +619,56 @@ mission "Apoxys Level 86"
 			action
 				outfit "Shields V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 86" "Chose shield upgrade."
+				log Levels "Apoxys" "Level 86: Chose shield upgrade."
 			`"More shields sound good, captain!" Maribelle replies giddily.`
 				goto next
 			label hullcap
 			action
 				outfit "Hull V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 86" "Chose hull upgrade."
+				log Levels "Apoxys" "Level 86: Chose hull upgrade."
 			`"More hull sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label outfitcap
 			action
 				outfit "Outfit V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 86" "Chose outfit upgrade."
+				log Levels "Apoxys" "Level 86: Chose outfit upgrade."
 			`"More space sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label heatcap
 			action
 				outfit "Heat Capacity V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 86" "Chose heat capacity upgrade."
+				log Levels "Apoxys" "Level 86: Chose heat capacity upgrade."
 			`"More heat capacity sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label weaponcap
 			action
 				outfit "Weapons V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 86" "Chose weapon upgrade."
+				log Levels "Apoxys" "Level 86: Chose weapon upgrade."
 			`"More weaponry sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label enginecap
 			action
 				outfit "Engines V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 86" "Chose engine upgrade."
+				log Levels "Apoxys" "Level 86: Chose engine upgrade."
 			`"More engine capabilities sound good, captain!" Maribelle replies giddily.`
 				goto next
 			label cargocap
 			action
 				outfit "Cargo V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 86" "Chose cargo upgrade."
+				log Levels "Apoxys" "Level 86: Chose cargo upgrade."
 			`"More carrying capacity sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label bunkcap
 			action
 				outfit "Bunks V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 86" "Chose bunk upgrade."
+				log Levels "Apoxys" "Level 86: Chose bunk upgrade."
 			`"I'll be sure it's done, captain," Maribelle replies.`
 				goto next
 
@@ -715,56 +715,56 @@ mission "Apoxys Level 87"
 			action
 				outfit "Shields V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 87" "Chose shield upgrade."
+				log Levels "Apoxys" "Level 87: Chose shield upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Only the strongest shields to keep the bad things out!"`
 				decline
 			label hullcap
 			action
 				outfit "Hull V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 87" "Chose hull upgrade."
+				log Levels "Apoxys" "Level 87: Chose hull upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. The most durable hull, for resisting all that space throws at us!"`
 				decline
 			label outfitcap
 			action
 				outfit "Outfit V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 87" "Chose outfit upgrade."
+				log Levels "Apoxys" "Level 87: Chose outfit upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Just imagine what we can do with all the extra space!"`
 				decline
 			label heatcap
 			action
 				outfit "Heat Capacity V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 87" "Chose heat capacity upgrade."
+				log Levels "Apoxys" "Level 87: Chose heat capacity upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Heat shouldn't be nearly as much of an issue, now!"`
 				decline
 			label weaponcap
 			action
 				outfit "Weapons V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 87" "Chose weapon upgrade."
+				log Levels "Apoxys" "Level 87: Chose weapon upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Our projectiles will blot out the sun! Maybe even a couple suns."`
 				decline
 			label enginecap
 			action
 				outfit "Engines V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 87" "Chose engine upgrade."
+				log Levels "Apoxys" "Level 87: Chose engine upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Our engines will move us like a moth to a flame! Ideally without the burning alive part."`
 				decline
 			label cargocap
 			action
 				outfit "Cargo V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 87" "Chose cargo upgrade."
+				log Levels "Apoxys" "Level 87: Chose cargo upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. We'll be able to carry plenty of goodies now!"`
 				decline
 			label bunkcap
 			action
 				outfit "Bunks V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 87" "Chose bunk upgrade."
+				log Levels "Apoxys" "Level 87: Chose bunk upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. We'll have room for all sorts of friends!"`
 				decline
 
@@ -806,56 +806,56 @@ mission "Apoxys Level 88"
 			action
 				outfit "Shields V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 88" "Chose shield upgrade."
+				log Levels "Apoxys" "Level 88: Chose shield upgrade."
 			`"More shields sound good, captain!" Maribelle replies giddily.`
 				goto next
 			label hullcap
 			action
 				outfit "Hull V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 88" "Chose hull upgrade."
+				log Levels "Apoxys" "Level 88: Chose hull upgrade."
 			`"More hull sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label outfitcap
 			action
 				outfit "Outfit V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 88" "Chose outfit upgrade."
+				log Levels "Apoxys" "Level 88: Chose outfit upgrade."
 			`"More space sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label heatcap
 			action
 				outfit "Heat Capacity V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 88" "Chose heat capacity upgrade."
+				log Levels "Apoxys" "Level 88: Chose heat capacity upgrade."
 			`"More heat capacity sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label weaponcap
 			action
 				outfit "Weapons V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 88" "Chose weapon upgrade."
+				log Levels "Apoxys" "Level 88: Chose weapon upgrade."
 			`"More weaponry sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label enginecap
 			action
 				outfit "Engines V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 88" "Chose engine upgrade."
+				log Levels "Apoxys" "Level 88: Chose engine upgrade."
 			`"More engine capabilities sound good, captain!" Maribelle replies giddily.`
 				goto next
 			label cargocap
 			action
 				outfit "Cargo V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 88" "Chose cargo upgrade."
+				log Levels "Apoxys" "Level 88: Chose cargo upgrade."
 			`"More carrying capacity sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label bunkcap
 			action
 				outfit "Bunks V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 88" "Chose bunk upgrade."
+				log Levels "Apoxys" "Level 88: Chose bunk upgrade."
 			`"I'll be sure it's done, captain," Maribelle replies.`
 				goto next
 
@@ -902,56 +902,56 @@ mission "Apoxys Level 89"
 			action
 				outfit "Shields V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 89" "Chose shield upgrade."
+				log Levels "Apoxys" "Level 89: Chose shield upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Only the strongest shields to keep the bad things out!"`
 				decline
 			label hullcap
 			action
 				outfit "Hull V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 89" "Chose hull upgrade."
+				log Levels "Apoxys" "Level 89: Chose hull upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. The most durable hull, for resisting all that space throws at us!"`
 				decline
 			label outfitcap
 			action
 				outfit "Outfit V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 89" "Chose outfit upgrade."
+				log Levels "Apoxys" "Level 89: Chose outfit upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Just imagine what we can do with all the extra space!"`
 				decline
 			label heatcap
 			action
 				outfit "Heat Capacity V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 89" "Chose heat capacity upgrade."
+				log Levels "Apoxys" "Level 89: Chose heat capacity upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Heat shouldn't be nearly as much of an issue, now!"`
 				decline
 			label weaponcap
 			action
 				outfit "Weapons V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 89" "Chose weapon upgrade."
+				log Levels "Apoxys" "Level 89: Chose weapon upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Our projectiles will blot out the sun! Maybe even a couple suns."`
 				decline
 			label enginecap
 			action
 				outfit "Engines V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 89" "Chose engine upgrade."
+				log Levels "Apoxys" "Level 89: Chose engine upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Our engines will move us like a moth to a flame! Ideally without the burning alive part."`
 				decline
 			label cargocap
 			action
 				outfit "Cargo V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 89" "Chose cargo upgrade."
+				log Levels "Apoxys" "Level 89: Chose cargo upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. We'll be able to carry plenty of goodies now!"`
 				decline
 			label bunkcap
 			action
 				outfit "Bunks V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 89" "Chose bunk upgrade."
+				log Levels "Apoxys" "Level 89: Chose bunk upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. We'll have room for all sorts of friends!"`
 				decline
 
@@ -992,56 +992,56 @@ mission "Apoxys Level 90"
 			action
 				outfit "Shields V" 1
 				outfit "Milestone V" 1
-				log Levels "Level 90" "Chose shield upgrade."
+				log Levels "Apoxys" "Level 90: Chose shield upgrade."
 			`Maribelle nods. "I'll be sure to have it done," She says, "Now..."`
 				goto next
 			label hullcap
 			action
 				outfit "Hull V" 1
 				outfit "Milestone V" 1
-				log Levels "Level 90" "Chose hull upgrade."
+				log Levels "Apoxys" "Level 90: Chose hull upgrade."
 			`Maribelle nods. "I'll be sure to have it done," She says, "Now..."`
 				goto next
 			label outfitcap
 			action
 				outfit "Outfit V" 1
 				outfit "Milestone V" 1
-				log Levels "Level 90" "Chose outfit upgrade."
+				log Levels "Apoxys" "Level 90: Chose outfit upgrade."
 			`Maribelle nods. "I'll be sure to have it done," She says, "Now..."`
 				goto next
 			label heatcap
 			action
 				outfit "Heat Capacity V" 1
 				outfit "Milestone V" 1
-				log Levels "Level 90" "Chose heat capacity upgrade."
+				log Levels "Apoxys" "Level 90: Chose heat capacity upgrade."
 			`Maribelle nods. "I'll be sure to have it done," She says, "Now..."`
 				goto next
 			label weaponcap
 			action
 				outfit "Weapons V" 1
 				outfit "Milestone V" 1
-				log Levels "Level 90" "Chose weapon upgrade."
+				log Levels "Apoxys" "Level 90: Chose weapon upgrade."
 			`Maribelle nods. "I'll be sure to have it done," She says, "Now..."`
 				goto next
 			label enginecap
 			action
 				outfit "Engines V" 1
 				outfit "Milestone V" 1
-				log Levels "Level 90" "Chose engine upgrade."
+				log Levels "Apoxys" "Level 90: Chose engine upgrade."
 			`Maribelle nods. "I'll be sure to have it done," She says, "Now..."`
 				goto next
 			label cargocap
 			action
 				outfit "Cargo V" 1
 				outfit "Milestone V" 1
-				log Levels "Level 90" "Chose cargo upgrade."
+				log Levels "Apoxys" "Level 90: Chose cargo upgrade."
 			`Maribelle nods. "I'll be sure to have it done," She says, "Now..."`
 				goto next
 			label bunkcap
 			action
 				outfit "Bunks V" 1
 				outfit "Milestone V" 1
-				log Levels "Level 90" "Chose bunk upgrade."
+				log Levels "Apoxys" "Level 90: Chose bunk upgrade."
 			`Maribelle nods. "I'll be sure to have it done," She says, "Now..."`
 				goto next
 
@@ -1088,56 +1088,56 @@ mission "Apoxys Level 91"
 			action
 				outfit "Shields V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 91" "Chose shield upgrade."
+				log Levels "Apoxys" "Level 91: Chose shield upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Only the strongest shields to keep the bad things out!"`
 				decline
 			label hullcap
 			action
 				outfit "Hull V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 91" "Chose hull upgrade."
+				log Levels "Apoxys" "Level 91: Chose hull upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. The most durable hull, for resisting all that space throws at us!"`
 				decline
 			label outfitcap
 			action
 				outfit "Outfit V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 91" "Chose outfit upgrade."
+				log Levels "Apoxys" "Level 91: Chose outfit upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Just imagine what we can do with all the extra space!"`
 				decline
 			label heatcap
 			action
 				outfit "Heat Capacity V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 91" "Chose heat capacity upgrade."
+				log Levels "Apoxys" "Level 91: Chose heat capacity upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Heat shouldn't be nearly as much of an issue, now!"`
 				decline
 			label weaponcap
 			action
 				outfit "Weapons V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 91" "Chose weapon upgrade."
+				log Levels "Apoxys" "Level 91: Chose weapon upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Our projectiles will blot out the sun! Maybe even a couple suns."`
 				decline
 			label enginecap
 			action
 				outfit "Engines V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 91" "Chose engine upgrade."
+				log Levels "Apoxys" "Level 91: Chose engine upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Our engines will move us like a moth to a flame! Ideally without the burning alive part."`
 				decline
 			label cargocap
 			action
 				outfit "Cargo V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 91" "Chose cargo upgrade."
+				log Levels "Apoxys" "Level 91: Chose cargo upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. We'll be able to carry plenty of goodies now!"`
 				decline
 			label bunkcap
 			action
 				outfit "Bunks V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 91" "Chose bunk upgrade."
+				log Levels "Apoxys" "Level 91: Chose bunk upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. We'll have room for all sorts of friends!"`
 				decline
 
@@ -1179,56 +1179,56 @@ mission "Apoxys Level 92"
 			action
 				outfit "Shields V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 92" "Chose shield upgrade."
+				log Levels "Apoxys" "Level 92: Chose shield upgrade."
 			`"I'll be sure it's done, captain," Maribelle replies.`
 				goto next
 			label hullcap
 			action
 				outfit "Hull V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 92" "Chose hull upgrade."
+				log Levels "Apoxys" "Level 92: Chose hull upgrade."
 			`"I'll be sure it's done, captain," Maribelle replies.`
 				goto next
 			label outfitcap
 			action
 				outfit "Outfit V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 92" "Chose outfit upgrade."
+				log Levels "Apoxys" "Level 92: Chose outfit upgrade."
 			`"I'll be sure it's done, captain," Maribelle replies.`
 				goto next
 			label heatcap
 			action
 				outfit "Heat Capacity V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 92" "Chose heat capacity upgrade."
+				log Levels "Apoxys" "Level 92: Chose heat capacity upgrade."
 			`"I'll be sure it's done, captain," Maribelle replies.`
 				goto next
 			label weaponcap
 			action
 				outfit "Weapons V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 92" "Chose weapon upgrade."
+				log Levels "Apoxys" "Level 92: Chose weapon upgrade."
 			`"I'll be sure it's done, captain," Maribelle replies.`
 				goto next
 			label enginecap
 			action
 				outfit "Engines V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 92" "Chose engine upgrade."
+				log Levels "Apoxys" "Level 92: Chose engine upgrade."
 			`"I'll be sure it's done, captain," Maribelle replies.`
 				goto next
 			label cargocap
 			action
 				outfit "Cargo V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 92" "Chose cargo upgrade."
+				log Levels "Apoxys" "Level 92: Chose cargo upgrade."
 			`"I'll be sure it's done, captain," Maribelle replies.`
 				goto next
 			label bunkcap
 			action
 				outfit "Bunks V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 92" "Chose bunk upgrade."
+				log Levels "Apoxys" "Level 92: Chose bunk upgrade."
 			`"I'll be sure it's done, captain," Maribelle replies.`
 				goto next
 
@@ -1276,56 +1276,56 @@ mission "Apoxys Level 93"
 			action
 				outfit "Shields V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 93" "Chose shield upgrade."
+				log Levels "Apoxys" "Level 93: Chose shield upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Only the strongest shields to keep the bad things out!"`
 				decline
 			label hullcap
 			action
 				outfit "Hull V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 93" "Chose hull upgrade."
+				log Levels "Apoxys" "Level 93: Chose hull upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. The most durable hull, for resisting all that space throws at us!"`
 				decline
 			label outfitcap
 			action
 				outfit "Outfit V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 93" "Chose outfit upgrade."
+				log Levels "Apoxys" "Level 93: Chose outfit upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Just imagine what we can do with all the extra space!"`
 				decline
 			label heatcap
 			action
 				outfit "Heat Capacity V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 93" "Chose heat capacity upgrade."
+				log Levels "Apoxys" "Level 93: Chose heat capacity upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Heat shouldn't be nearly as much of an issue, now!"`
 				decline
 			label weaponcap
 			action
 				outfit "Weapons V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 93" "Chose weapon upgrade."
+				log Levels "Apoxys" "Level 93: Chose weapon upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Our projectiles will blot out the sun! Maybe even a couple suns."`
 				decline
 			label enginecap
 			action
 				outfit "Engines V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 93" "Chose engine upgrade."
+				log Levels "Apoxys" "Level 93: Chose engine upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Our engines will move us like a moth to a flame! Ideally without the burning alive part."`
 				decline
 			label cargocap
 			action
 				outfit "Cargo V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 93" "Chose cargo upgrade."
+				log Levels "Apoxys" "Level 93: Chose cargo upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. We'll be able to carry plenty of goodies now!"`
 				decline
 			label bunkcap
 			action
 				outfit "Bunks V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 93" "Chose bunk upgrade."
+				log Levels "Apoxys" "Level 93: Chose bunk upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. We'll have room for all sorts of friends!"`
 				decline
 
@@ -1367,56 +1367,56 @@ mission "Apoxys Level 94"
 			action
 				outfit "Shields V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 94" "Chose shield upgrade."
+				log Levels "Apoxys" "Level 94: Chose shield upgrade."
 			`"More shields sound good, captain!" Maribelle replies giddily.`
 				goto next
 			label hullcap
 			action
 				outfit "Hull V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 94" "Chose hull upgrade."
+				log Levels "Apoxys" "Level 94: Chose hull upgrade."
 			`"More hull sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label outfitcap
 			action
 				outfit "Outfit V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 94" "Chose outfit upgrade."
+				log Levels "Apoxys" "Level 94: Chose outfit upgrade."
 			`"More space sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label heatcap
 			action
 				outfit "Heat Capacity V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 94" "Chose heat capacity upgrade."
+				log Levels "Apoxys" "Level 94: Chose heat capacity upgrade."
 			`"More heat capacity sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label weaponcap
 			action
 				outfit "Weapons V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 94" "Chose weapon upgrade."
+				log Levels "Apoxys" "Level 94: Chose weapon upgrade."
 			`"More weaponry sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label enginecap
 			action
 				outfit "Engines V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 94" "Chose engine upgrade."
+				log Levels "Apoxys" "Level 94: Chose engine upgrade."
 			`"More engine capabilities sound good, captain!" Maribelle replies giddily.`
 				goto next
 			label cargocap
 			action
 				outfit "Cargo V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 94" "Chose cargo upgrade."
+				log Levels "Apoxys" "Level 94: Chose cargo upgrade."
 			`"More carrying capacity sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label bunkcap
 			action
 				outfit "Bunks V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 94" "Chose bunk upgrade."
+				log Levels "Apoxys" "Level 94: Chose bunk upgrade."
 			`"I'll be sure it's done, captain," Maribelle replies.`
 				goto next
 
@@ -1463,56 +1463,56 @@ mission "Apoxys Level 95"
 			action
 				outfit "Shields V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 95" "Chose shield upgrade."
+				log Levels "Apoxys" "Level 95: Chose shield upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Only the strongest shields to keep the bad things out!"`
 				decline
 			label hullcap
 			action
 				outfit "Hull V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 95" "Chose hull upgrade."
+				log Levels "Apoxys" "Level 95: Chose hull upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. The most durable hull, for resisting all that space throws at us!"`
 				decline
 			label outfitcap
 			action
 				outfit "Outfit V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 95" "Chose outfit upgrade."
+				log Levels "Apoxys" "Level 95: Chose outfit upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Just imagine what we can do with all the extra space!"`
 				decline
 			label heatcap
 			action
 				outfit "Heat Capacity V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 95" "Chose heat capacity upgrade."
+				log Levels "Apoxys" "Level 95: Chose heat capacity upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Heat shouldn't be nearly as much of an issue, now!"`
 				decline
 			label weaponcap
 			action
 				outfit "Weapons V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 95" "Chose weapon upgrade."
+				log Levels "Apoxys" "Level 95: Chose weapon upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Our projectiles will blot out the sun! Maybe even a couple suns."`
 				decline
 			label enginecap
 			action
 				outfit "Engines V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 95" "Chose engine upgrade."
+				log Levels "Apoxys" "Level 95: Chose engine upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Our engines will move us like a moth to a flame! Ideally without the burning alive part."`
 				decline
 			label cargocap
 			action
 				outfit "Cargo V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 95" "Chose cargo upgrade."
+				log Levels "Apoxys" "Level 95: Chose cargo upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. We'll be able to carry plenty of goodies now!"`
 				decline
 			label bunkcap
 			action
 				outfit "Bunks V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 95" "Chose bunk upgrade."
+				log Levels "Apoxys" "Level 95: Chose bunk upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. We'll have room for all sorts of friends!"`
 				decline
 
@@ -1554,56 +1554,56 @@ mission "Apoxys Level 96"
 			action
 				outfit "Shields V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 96" "Chose shield upgrade."
+				log Levels "Apoxys" "Level 96: Chose shield upgrade."
 			`"More shields sound good, captain!" Maribelle replies giddily.`
 				goto next
 			label hullcap
 			action
 				outfit "Hull V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 96" "Chose hull upgrade."
+				log Levels "Apoxys" "Level 96: Chose hull upgrade."
 			`"More hull sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label outfitcap
 			action
 				outfit "Outfit V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 96" "Chose outfit upgrade."
+				log Levels "Apoxys" "Level 96: Chose outfit upgrade."
 			`"More space sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label heatcap
 			action
 				outfit "Heat Capacity V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 96" "Chose heat capacity upgrade."
+				log Levels "Apoxys" "Level 96: Chose heat capacity upgrade."
 			`"More heat capacity sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label weaponcap
 			action
 				outfit "Weapons V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 96" "Chose weapon upgrade."
+				log Levels "Apoxys" "Level 96: Chose weapon upgrade."
 			`"More weaponry sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label enginecap
 			action
 				outfit "Engines V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 96" "Chose engine upgrade."
+				log Levels "Apoxys" "Level 96: Chose engine upgrade."
 			`"More engine capabilities sound good, captain!" Maribelle replies giddily.`
 				goto next
 			label cargocap
 			action
 				outfit "Cargo V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 96" "Chose cargo upgrade."
+				log Levels "Apoxys" "Level 96: Chose cargo upgrade."
 			`"More carrying capacity sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label bunkcap
 			action
 				outfit "Bunks V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 96" "Chose bunk upgrade."
+				log Levels "Apoxys" "Level 96: Chose bunk upgrade."
 			`"I'll be sure it's done, captain," Maribelle replies.`
 				goto next
 
@@ -1650,56 +1650,56 @@ mission "Apoxys Level 97"
 			action
 				outfit "Shields V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 97" "Chose shield upgrade."
+				log Levels "Apoxys" "Level 97: Chose shield upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Only the strongest shields to keep the bad things out!"`
 				decline
 			label hullcap
 			action
 				outfit "Hull V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 97" "Chose hull upgrade."
+				log Levels "Apoxys" "Level 97: Chose hull upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. The most durable hull, for resisting all that space throws at us!"`
 				decline
 			label outfitcap
 			action
 				outfit "Outfit V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 97" "Chose outfit upgrade."
+				log Levels "Apoxys" "Level 97: Chose outfit upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Just imagine what we can do with all the extra space!"`
 				decline
 			label heatcap
 			action
 				outfit "Heat Capacity V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 97" "Chose heat capacity upgrade."
+				log Levels "Apoxys" "Level 97: Chose heat capacity upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Heat shouldn't be nearly as much of an issue, now!"`
 				decline
 			label weaponcap
 			action
 				outfit "Weapons V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 97" "Chose weapon upgrade."
+				log Levels "Apoxys" "Level 97: Chose weapon upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Our projectiles will blot out the sun! Maybe even a couple suns."`
 				decline
 			label enginecap
 			action
 				outfit "Engines V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 97" "Chose engine upgrade."
+				log Levels "Apoxys" "Level 97: Chose engine upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Our engines will move us like a moth to a flame! Ideally without the burning alive part."`
 				decline
 			label cargocap
 			action
 				outfit "Cargo V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 97" "Chose cargo upgrade."
+				log Levels "Apoxys" "Level 97: Chose cargo upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. We'll be able to carry plenty of goodies now!"`
 				decline
 			label bunkcap
 			action
 				outfit "Bunks V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 97" "Chose bunk upgrade."
+				log Levels "Apoxys" "Level 97: Chose bunk upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. We'll have room for all sorts of friends!"`
 				decline
 
@@ -1755,42 +1755,42 @@ mission "Apoxys Level 98"
 			action
 				outfit "Outfit V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 98" "Chose outfit upgrade."
+				log Levels "Apoxys" "Level 98: Chose outfit upgrade."
 			`"More space sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label heatcap
 			action
 				outfit "Heat Capacity V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 98" "Chose heat capacity upgrade."
+				log Levels "Apoxys" "Level 98: Chose heat capacity upgrade."
 			`"More heat capacity sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label weaponcap
 			action
 				outfit "Weapons V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 98" "Chose weapon upgrade."
+				log Levels "Apoxys" "Level 98: Chose weapon upgrade."
 			`"More weaponry sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label enginecap
 			action
 				outfit "Engines V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 98" "Chose engine upgrade."
+				log Levels "Apoxys" "Level 98: Chose engine upgrade."
 			`"More engine capabilities sound good, captain!" Maribelle replies giddily.`
 				goto next
 			label cargocap
 			action
 				outfit "Cargo V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 98" "Chose cargo upgrade."
+				log Levels "Apoxys" "Level 98: Chose cargo upgrade."
 			`"More carrying capacity sounds good, captain!" Maribelle replies giddily.`
 				goto next
 			label bunkcap
 			action
 				outfit "Bunks V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 98" "Chose bunk upgrade."
+				log Levels "Apoxys" "Level 98: Chose bunk upgrade."
 			`"I'll be sure it's done, captain," Maribelle replies.`
 				goto next
 
@@ -1837,56 +1837,56 @@ mission "Apoxys Level 99"
 			action
 				outfit "Shields V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 99" "Chose shield upgrade."
+				log Levels "Apoxys" "Level 99: Chose shield upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Only the strongest shields to keep the bad things out!"`
 				decline
 			label hullcap
 			action
 				outfit "Hull V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 99" "Chose hull upgrade."
+				log Levels "Apoxys" "Level 99: Chose hull upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. The most durable hull, for resisting all that space throws at us!"`
 				decline
 			label outfitcap
 			action
 				outfit "Outfit V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 99" "Chose outfit upgrade."
+				log Levels "Apoxys" "Level 99: Chose outfit upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Just imagine what we can do with all the extra space!"`
 				decline
 			label heatcap
 			action
 				outfit "Heat Capacity V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 99" "Chose heat capacity upgrade."
+				log Levels "Apoxys" "Level 99: Chose heat capacity upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Heat shouldn't be nearly as much of an issue, now!"`
 				decline
 			label weaponcap
 			action
 				outfit "Weapons V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 99" "Chose weapon upgrade."
+				log Levels "Apoxys" "Level 99: Chose weapon upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Our projectiles will blot out the sun! Maybe even a couple suns."`
 				decline
 			label enginecap
 			action
 				outfit "Engines V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 99" "Chose engine upgrade."
+				log Levels "Apoxys" "Level 99: Chose engine upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. Our engines will move us like a moth to a flame! Ideally without the burning alive part."`
 				decline
 			label cargocap
 			action
 				outfit "Cargo V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 99" "Chose cargo upgrade."
+				log Levels "Apoxys" "Level 99: Chose cargo upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. We'll be able to carry plenty of goodies now!"`
 				decline
 			label bunkcap
 			action
 				outfit "Bunks V" 1
 				outfit "Basal Level V" 1
-				log Levels "Level 99" "Chose bunk upgrade."
+				log Levels "Apoxys" "Level 99: Chose bunk upgrade."
 			`"Okay!" Maribelle replies, quite happy with your input, "I'll do just that, then Captain. We'll have room for all sorts of friends!"`
 				decline
 

--- a/data/apoxys/perks list.txt
+++ b/data/apoxys/perks list.txt
@@ -507,7 +507,7 @@ conversation "perkslist"
 	action
 		"apoxys spec points" += 1
 		outfit "Fortitude" -1
-	`Fortitude increased by 1 (now &[outfit (flagship installed): Fortitude]).`
+	`Fortitude decreased by 1 (now &[outfit (flagship installed): Fortitude]).`
 		goto fortitude
 
 	label force
@@ -533,7 +533,7 @@ conversation "perkslist"
 	action
 		"apoxys spec points" += 1
 		outfit "Force" -1
-	`Force increased by 1 (now &[outfit (flagship installed): Force]).`
+	`Force decreased by 1 (now &[outfit (flagship installed): Force]).`
 		goto force
 
 	label focus
@@ -559,7 +559,7 @@ conversation "perkslist"
 	action
 		"apoxys spec points" += 1
 		outfit "Focus" -1
-	`Focus increased by 1 (now &[outfit (flagship installed): Focus]).`
+	`Focus decreased by 1 (now &[outfit (flagship installed): Focus]).`
 		goto focus
 
 	label flightiness
@@ -585,7 +585,7 @@ conversation "perkslist"
 	action
 		"apoxys spec points" += 1
 		outfit "Flightiness" -1
-	`Flightiness increased by 1 (now &[outfit (flagship installed): Flightiness]).`
+	`Flightiness decreased by 1 (now &[outfit (flagship installed): Flightiness]).`
 		goto flightiness
 
 	label friendliness
@@ -611,7 +611,7 @@ conversation "perkslist"
 	action
 		"apoxys spec points" += 1
 		outfit "Friendliness" -1
-	`Friendliness increased by 1 (now &[outfit (flagship installed): Friendliness]).`
+	`Friendliness decreased by 1 (now &[outfit (flagship installed): Friendliness]).`
 		goto friendliness
 
 	label shieldoverclock

--- a/data/apoxys/perks list.txt
+++ b/data/apoxys/perks list.txt
@@ -13,8 +13,384 @@ mission "Apoxys Perks List"
 conversation "perkslist"
 	`Before you lies a large list of 'perks'; special upgrades that may alter how the ship handles in more drastic ways than simple level-up stat boosts. Be sure to read descriptions carefully!`
 	label hub
+	branch "available perks" "all perks"
+		"apoxys show all perks" == 0
+
+	label "available perks"
 	`	You have &[perk in waiting] perks left.`
 	choice
+		`	(Show all perks.)
+				action
+					"apoxys show all perks" = 1
+			goto "all perks"
+		`	(Core Restructure.)`
+			goto corerestructure
+		`	(Shield Overclock.)`
+			to display
+				or
+					and
+						has "Apoxys Level 2: declined"
+						"outfit (flagship installed): Perk: Shield Overclock" == 0
+					and
+						has "Apoxys Level 6: declined"
+						"outfit (flagship installed): Perk: Shield Overclock" == 1
+					and
+						has "Apoxys Level 10: declined"
+						"outfit (flagship installed): Perk: Shield Overclock" == 2
+					and
+						has "Apoxys Level 14: declined"
+						"outfit (flagship installed): Perk: Shield Overclock" == 3
+					and
+						has "Apoxys Level 20: declined"
+						"outfit (flagship installed): Perk: Shield Overclock" == 4
+					and
+						has "Apoxys Level 30: declined"
+						"outfit (flagship installed): Perk: Shield Overclock" == 5
+					and
+						has "Apoxys Level 42: declined"
+						"outfit (flagship installed): Perk: Shield Overclock" == 6
+					and
+						has "Apoxys Level 56: declined"
+						"outfit (flagship installed): Perk: Shield Overclock" == 7
+					and
+						has "Apoxys Level 72: declined"
+						"outfit (flagship installed): Perk: Shield Overclock" == 8
+					and
+						has "Apoxys Level 90: declined"
+						"outfit (flagship installed): Perk: Shield Overclock" == 9
+					has "Apoxys Level 100 Choices: declined"
+			goto shieldoverclock
+		`	(Heat Dissipation.)`
+			to display
+				or
+					and
+						has "Apoxys Level 2: declined"
+						"outfit (flagship installed): Perk: Heat Dissipation" == 0
+					and
+						has "Apoxys Level 14: declined"
+						"outfit (flagship installed): Perk: Heat Dissipation" == 1
+					and
+						has "Apoxys Level 30: declined"
+						"outfit (flagship installed): Perk: Heat Dissipation" == 2
+			goto heatdissipation
+		`	(Drag Reduction.)`
+			to display
+				or
+					and
+						has "Apoxys Level 8: declined"
+						"outfit (flagship installed): Perk: Drag Reduction" == 0
+					and
+						has "Apoxys Level 22: declined"
+						"outfit (flagship installed): Perk: Drag Reduction" == 1
+					and
+						has "Apoxys Level 40: declined"
+						"outfit (flagship installed): Perk: Drag Reduction" == 2
+					and
+						has "Apoxys Level 62: declined"
+						"outfit (flagship installed): Perk: Drag Reduction" == 3
+					and
+						has "Apoxys Level 86: declined"
+						"outfit (flagship installed): Perk: Drag Reduction" == 4
+			goto dragreduction
+		`	(No Pushover.)`
+			to display
+				or
+					and
+						has "Apoxys Level 4: declined"
+						"outfit (flagship installed): Perk: No Pushover" == 0
+					and
+						has "Apoxys Level 32: declined"
+						"outfit (flagship installed): Perk: No Pushover" == 1
+			goto nopushover
+		`	(Long Hauler.)`
+			to display
+				or
+					and
+						has "Apoxys Level 4: declined"
+						"outfit (flagship installed): Perk: Long Hauler" == 0
+					and
+						has "Apoxys Level 18: declined"
+						"outfit (flagship installed): Perk: Long Hauler" == 1
+					and
+						has "Apoxys Level 38: declined"
+						"outfit (flagship installed): Perk: Long Hauler" == 2
+					and
+						has "Apoxys Level 60: declined"
+						"outfit (flagship installed): Perk: Long Hauler" == 3
+					and
+						has "Apoxys Level 88: declined"
+						"outfit (flagship installed): Perk: Long Hauler" == 4
+			goto longhauler
+		`	(Heat Shielding.)`
+			to display
+				or
+					and
+						has "Apoxys Level 6: declined"
+						"outfit (flagship installed): Perk: Heat Shielding" == 0
+					and
+						has "Apoxys Level 24: declined"
+						"outfit (flagship installed): Perk: Heat Shielding" == 1
+					and
+						has "Apoxys Level 46: declined"
+						"outfit (flagship installed): Perk: Heat Shielding" == 2
+			goto heatshield
+		`	(Energy Shielding.)`
+			to display
+				or
+					and
+						has "Apoxys Level 6: declined"
+						"outfit (flagship installed): Perk: Energy Shielding" == 0
+					and
+						has "Apoxys Level 24: declined"
+						"outfit (flagship installed): Perk: Energy Shielding" == 1
+					and
+						has "Apoxys Level 46: declined"
+						"outfit (flagship installed): Perk: Energy Shielding" == 2
+			goto energyshield
+		`	(Artilleur.)`
+			to display
+				or
+					and
+						has "Apoxys Level 8: declined"
+						"outfit (flagship installed): Perk: Artilleur" == 0
+					and
+						has "Apoxys Level 30: declined"
+						"outfit (flagship installed): Perk: Artilleur" == 1
+					and
+						has "Apoxys Level 60: declined"
+						"outfit (flagship installed): Perk: Artilleur" == 2
+			goto artilleur
+		`	(Engineer.)`
+			to display
+				or
+					and
+						has "Apoxys Level 14: declined"
+						"outfit (flagship installed): Perk: Engineer" == 0
+					and
+						has "Apoxys Level 38: declined"
+						"outfit (flagship installed): Perk: Engineer" == 1
+					and
+						has "Apoxys Level 68: declined"
+						"outfit (flagship installed): Perk: Engineer" == 2
+			goto engineer
+		`	(Shieldsmith.)`
+			to display
+				or
+					and
+						has "Apoxys Level 14: declined"
+						"outfit (flagship installed): Perk: Shieldsmith" == 0
+					and
+						has "Apoxys Level 38: declined"
+						"outfit (flagship installed): Perk: Shieldsmith" == 1
+					and
+						has "Apoxys Level 80: declined"
+						"outfit (flagship installed): Perk: Shieldsmith" == 2
+			goto shieldsmith
+		`	(Natural Regeneration.)`
+			to display
+				or
+					and
+						has "Apoxys Level 6: declined"
+						"outfit (flagship installed): Perk: Natural Regeneration" == 0
+					and
+						has "Apoxys Level 22: declined"
+						"outfit (flagship installed): Perk: Natural Regeneration" == 1
+					and
+						has "Apoxys Level 30: declined"
+						"outfit (flagship installed): Perk: Natural Regeneration" == 2
+					and
+						has "Apoxys Level 42: declined"
+						"outfit (flagship installed): Perk: Natural Regeneration" == 3
+					and
+						has "Apoxys Level 56: declined"
+						"outfit (flagship installed): Perk: Natural Regeneration" == 4
+			goto naturalregeneration
+		`	(Natural Repair.)`
+			to display
+				or
+					and
+						has "Apoxys Level 8: declined"
+						"outfit (flagship installed): Perk: Natural Repair" == 0
+					and
+						has "Apoxys Level 24: declined"
+						"outfit (flagship installed): Perk: Natural Repair" == 1
+					and
+						has "Apoxys Level 32: declined"
+						"outfit (flagship installed): Perk: Natural Repair" == 2
+					and
+						has "Apoxys Level 44: declined"
+						"outfit (flagship installed): Perk: Natural Repair" == 3
+					and
+						has "Apoxys Level 58: declined"
+						"outfit (flagship installed): Perk: Natural Repair" == 4
+			goto naturalrepair
+		`	(Repair Overdrive.)`
+			to display
+				or
+					and
+						has "Apoxys Level 16: declined"
+						"outfit (flagship installed): Perk: Repair Overdrive" == 0
+					and
+						has "Apoxys Level 20: declined"
+						"outfit (flagship installed): Perk: Repair Overdrive" == 1
+					and
+						has "Apoxys Level 26: declined"
+						"outfit (flagship installed): Perk: Repair Overdrive" == 2
+					and
+						has "Apoxys Level 32: declined"
+						"outfit (flagship installed): Perk: Repair Overdrive" == 3
+					and
+						has "Apoxys Level 40: declined"
+						"outfit (flagship installed): Perk: Repair Overdrive" == 4
+					and
+						has "Apoxys Level 48: declined"
+						"outfit (flagship installed): Perk: Repair Overdrive" == 5
+					and
+						has "Apoxys Level 58: declined"
+						"outfit (flagship installed): Perk: Repair Overdrive" == 6
+					and
+						has "Apoxys Level 70: declined"
+						"outfit (flagship installed): Perk: Repair Overdrive" == 7
+					and
+						has "Apoxys Level 82: declined"
+						"outfit (flagship installed): Perk: Repair Overdrive" == 8
+					and
+						has "Apoxys Level 96: declined"
+						"outfit (flagship installed): Perk: Repair Overdrive" == 9
+					has "Apoxys Level 100 Choices: declined"
+			goto repairoverdrive
+		`	(Raider Rally.)`
+			to display
+				or
+					and
+						has "Apoxys Level 10: declined"
+						"outfit (flagship installed): Perk: Raider Rally" == 0
+					and
+						has "Apoxys Level 24: declined"
+						"outfit (flagship installed): Perk: Raider Rally" == 1
+					and
+						has "Apoxys Level 44: declined"
+						"outfit (flagship installed): Perk: Raider Rally" == 2
+					and
+						has "Apoxys Level 66: declined"
+						"outfit (flagship installed): Perk: Raider Rally" == 3
+					and
+						has "Apoxys Level 92: declined"
+						"outfit (flagship installed): Perk: Raider Rally" == 4
+			goto raiderrally
+		`	(Stellar Drinker.)`
+			to display
+				or
+					and
+						has "Apoxys Level 12: declined"
+						"outfit (flagship installed): Perk: Stellar Drinker" == 0
+					and
+						has "Apoxys Level 28: declined"
+						"outfit (flagship installed): Perk: Stellar Drinker" == 1
+					and
+						has "Apoxys Level 42: declined"
+						"outfit (flagship installed): Perk: Stellar Drinker" == 2
+			goto stellardrinker
+		`	(Sneaky Packer.)`
+			to display
+				or
+					and
+						has "Apoxys Level 12: declined"
+						"outfit (flagship installed): Perk: Sneaky Packer" == 0
+					and
+						has "Apoxys Level 22: declined"
+						"outfit (flagship installed): Perk: Sneaky Packer" == 1
+					and
+						has "Apoxys Level 34: declined"
+						"outfit (flagship installed): Perk: Sneaky Packer" == 2
+					and
+						has "Apoxys Level 48: declined"
+						"outfit (flagship installed): Perk: Sneaky Packer" == 3
+					and
+						has "Apoxys Level 58: declined"
+						"outfit (flagship installed): Perk: Sneaky Packer" == 4
+					and
+						has "Apoxys Level 70: declined"
+						"outfit (flagship installed): Perk: Sneaky Packer" == 5
+					and
+						has "Apoxys Level 82: declined"
+						"outfit (flagship installed): Perk: Sneaky Packer" == 6
+					and
+						has "Apoxys Level 94: declined"
+						"outfit (flagship installed): Perk: Sneaky Packer" == 7
+			goto sneakypacker
+		`	(Disassembler.)`
+			to display
+				and
+					has "Apoxys Level 28: declined"
+					"outfit (flagship installed): Perk: Disassembler" == 0
+			goto disassembler
+		`	(Missile Lover.)`
+			to display
+				and
+					has "Apoxys Level 36: declined"
+					"outfit (flagship installed): Perk: Missile Lover" == 0
+			goto missilelover
+		`	(Pick-Me-Up.)`
+			to display
+				and
+					has "Apoxys Level 54: declined"
+					"outfit (flagship installed): Perk: Pick-Me-Up" == 0
+					"outfit (flagship installed): Fortitude" >= 8
+			goto pickmeup
+		`	(Adrenal Surge.)`
+			to display
+				and
+					has "Apoxys Level 36: declined"
+					"outfit (flagship installed): Perk: Adrenal Surge" == 0
+					"outfit (flagship installed): Focus" >= 7
+			goto adrenalsurge
+		`	(Barrage Squad.)`
+			to display
+				and
+					2 <= ( "flagship bays: Drone" - ( ( 2 * "outfit (flagship installed): Perk: Barrage Squad" ) + "outfit (flagship installed): Perk: Crippler Squad" ) )
+					or
+						and
+							has "Apoxys Level 16: declined"
+							"outfit (flagship installed): Perk: Barrage Squad" == 0
+						and
+							has "Apoxys Level 34: declined"
+							"outfit (flagship installed): Perk: Barrage Squad" == 1
+						and
+							has "Apoxys Level 52: declined"
+							"outfit (flagship installed): Perk: Barrage Squad" == 2
+						and
+							has "Apoxys Level 70: declined"
+							"outfit (flagship installed): Perk: Barrage Squad" == 3
+						and
+							has "Apoxys Level 88: declined"
+							"outfit (flagship installed): Perk: Barrage Squad" == 4
+			goto barragesquad
+		`	(Crippler Squad.)`
+			to display
+				and
+					1 <= ( "flagship bays: Drone" - ( ( 2 * "outfit (flagship installed): Perk: Barrage Squad" ) + "outfit (flagship installed): Perk: Crippler Squad" ) )
+					or
+						and
+							has "Apoxys Level 16: declined"
+							"outfit (flagship installed): Perk: Crippler Squad" == 0
+						and
+							has "Apoxys Level 34: declined"
+							"outfit (flagship installed): Perk: Crippler Squad" == 1
+						and
+							has "Apoxys Level 52: declined"
+							"outfit (flagship installed): Perk: Crippler Squad" == 2
+			goto cripplersquad
+		`	(Not now.)`
+			defer
+
+	label "all perks"
+	`	You have &[perk in waiting] perks left.`
+	choice
+		`	(Show available perks only.)
+				action
+					"apoxys show all perks" = 0
+			goto "available perks"
 		`	(Core Restructure.)`
 			goto corerestructure
 		`	(Shield Overclock.)`

--- a/data/merchantsguild/merchantlevels1-20.txt
+++ b/data/merchantsguild/merchantlevels1-20.txt
@@ -108,7 +108,7 @@ mission "Merchant's Guild Level 1"
 				outfit "Shields I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 1
-				log "Merchant Levels" "Level 1" "Chose shield upgrade."
+				log Levels "Merchant" "	Level 1: Chose shield upgrade."
 			`Maribelle nods in agreement. "More shields can't hurt, can it?" She asks.`
 				decline
 			label hullcap
@@ -116,7 +116,7 @@ mission "Merchant's Guild Level 1"
 				outfit "Hull I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 1
-				log "Merchant Levels" "Level 1" "Chose hull upgrade."
+				log Levels "Merchant" "	Level 1: Chose hull upgrade."
 			`Maribelle nods in agreement. "More hull can't hurt, can it?" She asks.`
 				decline
 			label cargocap
@@ -124,7 +124,7 @@ mission "Merchant's Guild Level 1"
 				outfit "Cargo I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 1
-				log "Merchant Levels" "Level 1" "Chose cargo upgrade."
+				log Levels "Merchant" "	Level 1: Chose cargo upgrade."
 			`"Well, she is rewarding it for merchant work. It does make sense we'd want to do more, faster," Maribelle says.`
 				decline
 			label fuelcap
@@ -132,7 +132,7 @@ mission "Merchant's Guild Level 1"
 				outfit "Fuel I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 1
-				log "Merchant Levels" "Level 1" "Chose fuel upgrade."
+				log Levels "Merchant" "	Level 1: Chose fuel upgrade."
 			`"I didn't even know I could get my fuel capacity increased separately," Maribelle admits.`
 				decline
 			label jamming
@@ -140,7 +140,7 @@ mission "Merchant's Guild Level 1"
 				outfit "Jamming I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 1
-				log "Merchant Levels" "Level 1" "Chose jamming upgrade."
+				log Levels "Merchant" "	Level 1: Chose jamming upgrade."
 			`"Jamming? Wow, I never even thought about that before," Maribelle says. "It should alleviate some missile pressure, shouldn't it?"`
 				decline
 			label concealment
@@ -148,7 +148,7 @@ mission "Merchant's Guild Level 1"
 				outfit "Concealment I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 1
-				log "Merchant Levels" "Level 1" "Chose concealment upgrade."
+				log Levels "Merchant" "	Level 1: Chose concealment upgrade."
 			`"Ooh, concealment? What are you trying to hide, Captain? An embarassing sixth-grade photo?" Maribelle jokes, giggling.`
 				decline
 
@@ -186,7 +186,7 @@ mission "Merchant's Guild Level 2"
 				outfit "Shields I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 2
-				log "Merchant Levels" "Level 2" "Chose shield upgrade."
+				log Levels "Merchant" "Level 2: Chose shield upgrade."
 			`Maribelle nods in agreement. "More shields can't hurt, can it?" She asks.`
 				goto next
 			label hullcap
@@ -194,7 +194,7 @@ mission "Merchant's Guild Level 2"
 				outfit "Hull I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 2
-				log "Merchant Levels" "Level 2" "Chose hull upgrade."
+				log Levels "Merchant" "Level 2: Chose hull upgrade."
 			`Maribelle nods in agreement. "More hull can't hurt, can it?" She asks.`
 				goto next
 			label cargocap
@@ -202,7 +202,7 @@ mission "Merchant's Guild Level 2"
 				outfit "Cargo I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 2
-				log "Merchant Levels" "Level 2" "Chose cargo upgrade."
+				log Levels "Merchant" "Level 2: Chose cargo upgrade."
 			`"Well, she is rewarding it for merchant work. It does make sense we'd want to do more, faster," Maribelle says.`
 				goto next
 			label fuelcap
@@ -210,7 +210,7 @@ mission "Merchant's Guild Level 2"
 				outfit "Fuel I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 2
-				log "Merchant Levels" "Level 2" "Chose fuel upgrade."
+				log Levels "Merchant" "Level 2: Chose fuel upgrade."
 			`"I didn't even know I could get my fuel capacity increased separately," Maribelle admits.`
 				goto next
 			label jamming
@@ -218,7 +218,7 @@ mission "Merchant's Guild Level 2"
 				outfit "Jamming I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 2
-				log "Merchant Levels" "Level 2" "Chose jamming upgrade."
+				log Levels "Merchant" "Level 2: Chose jamming upgrade."
 			`"Jamming? Wow, I never even thought about that before," Maribelle says. "It should alleviate some missile pressure, shouldn't it?"`
 				goto next
 			label concealment
@@ -226,7 +226,7 @@ mission "Merchant's Guild Level 2"
 				outfit "Concealment I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 2
-				log "Merchant Levels" "Level 2" "Chose concealment upgrade."
+				log Levels "Merchant" "Level 2: Chose concealment upgrade."
 			`"Ooh, concealment? What are you trying to hide, Captain? An embarassing sixth-grade photo?" Maribelle jokes, giggling.`
 				goto next
 
@@ -270,7 +270,7 @@ mission "Merchant's Guild Level 3"
 				outfit "Shields I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 3
-				log "Merchant Levels" "Level 3" "Chose shield upgrade."
+				log Levels "Merchant" "Level 3: Chose shield upgrade."
 			`Maribelle nods in agreement. "More shields can't hurt, can it?" She asks.`
 				decline
 			label hullcap
@@ -278,7 +278,7 @@ mission "Merchant's Guild Level 3"
 				outfit "Hull I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 3
-				log "Merchant Levels" "Level 3" "Chose hull upgrade."
+				log Levels "Merchant" "Level 3: Chose hull upgrade."
 			`Maribelle nods in agreement. "More hull can't hurt, can it?" She asks.`
 				decline
 			label cargocap
@@ -286,7 +286,7 @@ mission "Merchant's Guild Level 3"
 				outfit "Cargo I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 3
-				log "Merchant Levels" "Level 3" "Chose cargo upgrade."
+				log Levels "Merchant" "Level 3: Chose cargo upgrade."
 			`"Well, she is rewarding it for merchant work. It does make sense we'd want to do more, faster," Maribelle says.`
 				decline
 			label fuelcap
@@ -294,7 +294,7 @@ mission "Merchant's Guild Level 3"
 				outfit "Fuel I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 3
-				log "Merchant Levels" "Level 3" "Chose fuel upgrade."
+				log Levels "Merchant" "Level 3: Chose fuel upgrade."
 			`"I didn't even know I could get my fuel capacity increased separately," Maribelle admits.`
 				decline
 			label jamming
@@ -302,7 +302,7 @@ mission "Merchant's Guild Level 3"
 				outfit "Jamming I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 3
-				log "Merchant Levels" "Level 3" "Chose jamming upgrade."
+				log Levels "Merchant" "Level 3: Chose jamming upgrade."
 			`"Jamming? Wow, I never even thought about that before," Maribelle says. "It should alleviate some missile pressure, shouldn't it?"`
 				decline
 			label concealment
@@ -310,7 +310,7 @@ mission "Merchant's Guild Level 3"
 				outfit "Concealment I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 3
-				log "Merchant Levels" "Level 3" "Chose concealment upgrade."
+				log Levels "Merchant" "Level 3: Chose concealment upgrade."
 			`"Ooh, concealment? What are you trying to hide, Captain? An embarassing sixth-grade photo?" Maribelle jokes, giggling.`
 				decline
 
@@ -348,7 +348,7 @@ mission "Merchant's Guild Level 4"
 				outfit "Shields I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 4
-				log "Merchant Levels" "Level 4" "Chose shield upgrade."
+				log Levels "Merchant" "Level 4: Chose shield upgrade."
 			`Maribelle nods in agreement. "More shields can't hurt, can it?" She asks.`
 				goto next
 			label hullcap
@@ -356,7 +356,7 @@ mission "Merchant's Guild Level 4"
 				outfit "Hull I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 4
-				log "Merchant Levels" "Level 4" "Chose hull upgrade."
+				log Levels "Merchant" "Level 4: Chose hull upgrade."
 			`Maribelle nods in agreement. "More hull can't hurt, can it?" She asks.`
 				goto next
 			label cargocap
@@ -364,7 +364,7 @@ mission "Merchant's Guild Level 4"
 				outfit "Cargo I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 4
-				log "Merchant Levels" "Level 4" "Chose cargo upgrade."
+				log Levels "Merchant" "Level 4: Chose cargo upgrade."
 			`"Well, she is rewarding it for merchant work. It does make sense we'd want to do more, faster," Maribelle says.`
 				goto next
 			label fuelcap
@@ -372,7 +372,7 @@ mission "Merchant's Guild Level 4"
 				outfit "Fuel I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 4
-				log "Merchant Levels" "Level 4" "Chose fuel upgrade."
+				log Levels "Merchant" "Level 4: Chose fuel upgrade."
 			`"I didn't even know I could get my fuel capacity increased separately," Maribelle admits.`
 				goto next
 			label jamming
@@ -380,7 +380,7 @@ mission "Merchant's Guild Level 4"
 				outfit "Jamming I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 4
-				log "Merchant Levels" "Level 4" "Chose jamming upgrade."
+				log Levels "Merchant" "Level 4: Chose jamming upgrade."
 			`"Jamming? Wow, I never even thought about that before," Maribelle says. "It should alleviate some missile pressure, shouldn't it?"`
 				goto next
 			label concealment
@@ -388,7 +388,7 @@ mission "Merchant's Guild Level 4"
 				outfit "Concealment I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 4
-				log "Merchant Levels" "Level 4" "Chose concealment upgrade."
+				log Levels "Merchant" "Level 4: Chose concealment upgrade."
 			`"Ooh, concealment? What are you trying to hide, Captain? An embarassing sixth-grade photo?" Maribelle jokes, giggling.`
 				goto next
 
@@ -432,7 +432,7 @@ mission "Merchant's Guild Level 5"
 				outfit "Shields I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 5
-				log "Merchant Levels" "Level 5" "Chose shield upgrade."
+				log Levels "Merchant" "Level 5: Chose shield upgrade."
 			`Maribelle nods in agreement. "More shields can't hurt, can it?" She asks.`
 				decline
 			label hullcap
@@ -440,7 +440,7 @@ mission "Merchant's Guild Level 5"
 				outfit "Hull I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 5
-				log "Merchant Levels" "Level 5" "Chose hull upgrade."
+				log Levels "Merchant" "Level 5: Chose hull upgrade."
 			`Maribelle nods in agreement. "More hull can't hurt, can it?" She asks.`
 				decline
 			label cargocap
@@ -448,7 +448,7 @@ mission "Merchant's Guild Level 5"
 				outfit "Cargo I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 5
-				log "Merchant Levels" "Level 5" "Chose cargo upgrade."
+				log Levels "Merchant" "Level 5: Chose cargo upgrade."
 			`"Well, she is rewarding it for merchant work. It does make sense we'd want to do more, faster," Maribelle says.`
 				decline
 			label fuelcap
@@ -456,7 +456,7 @@ mission "Merchant's Guild Level 5"
 				outfit "Fuel I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 5
-				log "Merchant Levels" "Level 5" "Chose fuel upgrade."
+				log Levels "Merchant" "Level 5: Chose fuel upgrade."
 			`"I didn't even know I could get my fuel capacity increased separately," Maribelle admits.`
 				decline
 			label jamming
@@ -464,7 +464,7 @@ mission "Merchant's Guild Level 5"
 				outfit "Jamming I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 5
-				log "Merchant Levels" "Level 5" "Chose jamming upgrade."
+				log Levels "Merchant" "Level 5: Chose jamming upgrade."
 			`"Jamming? Wow, I never even thought about that before," Maribelle says. "It should alleviate some missile pressure, shouldn't it?"`
 				decline
 			label concealment
@@ -472,7 +472,7 @@ mission "Merchant's Guild Level 5"
 				outfit "Concealment I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 5
-				log "Merchant Levels" "Level 5" "Chose concealment upgrade."
+				log Levels "Merchant" "Level 5: Chose concealment upgrade."
 			`"Ooh, concealment? What are you trying to hide, Captain? An embarassing sixth-grade photo?" Maribelle jokes, giggling.`
 				decline
 
@@ -510,7 +510,7 @@ mission "Merchant's Guild Level 6"
 				outfit "Shields I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 6
-				log "Merchant Levels" "Level 6" "Chose shield upgrade."
+				log Levels "Merchant" "Level 6: Chose shield upgrade."
 			`Maribelle nods in agreement. "More shields can't hurt, can it?" She asks.`
 				goto next
 			label hullcap
@@ -518,7 +518,7 @@ mission "Merchant's Guild Level 6"
 				outfit "Hull I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 6
-				log "Merchant Levels" "Level 6" "Chose hull upgrade."
+				log Levels "Merchant" "Level 6: Chose hull upgrade."
 			`Maribelle nods in agreement. "More hull can't hurt, can it?" She asks.`
 				goto next
 			label cargocap
@@ -526,7 +526,7 @@ mission "Merchant's Guild Level 6"
 				outfit "Cargo I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 6
-				log "Merchant Levels" "Level 6" "Chose cargo upgrade."
+				log Levels "Merchant" "Level 6: Chose cargo upgrade."
 			`"Well, she is rewarding it for merchant work. It does make sense we'd want to do more, faster," Maribelle says.`
 				goto next
 			label fuelcap
@@ -534,7 +534,7 @@ mission "Merchant's Guild Level 6"
 				outfit "Fuel I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 6
-				log "Merchant Levels" "Level 6" "Chose fuel upgrade."
+				log Levels "Merchant" "Level 6: Chose fuel upgrade."
 			`"I didn't even know I could get my fuel capacity increased separately," Maribelle admits.`
 				goto next
 			label jamming
@@ -542,7 +542,7 @@ mission "Merchant's Guild Level 6"
 				outfit "Jamming I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 6
-				log "Merchant Levels" "Level 6" "Chose jamming upgrade."
+				log Levels "Merchant" "Level 6: Chose jamming upgrade."
 			`"Jamming? Wow, I never even thought about that before," Maribelle says. "It should alleviate some missile pressure, shouldn't it?"`
 				goto next
 			label concealment
@@ -550,7 +550,7 @@ mission "Merchant's Guild Level 6"
 				outfit "Concealment I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 6
-				log "Merchant Levels" "Level 6" "Chose concealment upgrade."
+				log Levels "Merchant" "Level 6: Chose concealment upgrade."
 			`"Ooh, concealment? What are you trying to hide, Captain? An embarassing sixth-grade photo?" Maribelle jokes, giggling.`
 				goto next
 
@@ -594,7 +594,7 @@ mission "Merchant's Guild Level 7"
 				outfit "Shields I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 7
-				log "Merchant Levels" "Level 7" "Chose shield upgrade."
+				log Levels "Merchant" "Level 7: Chose shield upgrade."
 			`Maribelle nods in agreement. "More shields can't hurt, can it?" She asks.`
 				decline
 			label hullcap
@@ -602,7 +602,7 @@ mission "Merchant's Guild Level 7"
 				outfit "Hull I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 7
-				log "Merchant Levels" "Level 7" "Chose hull upgrade."
+				log Levels "Merchant" "Level 7: Chose hull upgrade."
 			`Maribelle nods in agreement. "More hull can't hurt, can it?" She asks.`
 				decline
 			label cargocap
@@ -610,7 +610,7 @@ mission "Merchant's Guild Level 7"
 				outfit "Cargo I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 7
-				log "Merchant Levels" "Level 7" "Chose cargo upgrade."
+				log Levels "Merchant" "Level 7: Chose cargo upgrade."
 			`"Well, she is rewarding it for merchant work. It does make sense we'd want to do more, faster," Maribelle says.`
 				decline
 			label fuelcap
@@ -618,7 +618,7 @@ mission "Merchant's Guild Level 7"
 				outfit "Fuel I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 7
-				log "Merchant Levels" "Level 7" "Chose fuel upgrade."
+				log Levels "Merchant" "Level 7: Chose fuel upgrade."
 			`"I didn't even know I could get my fuel capacity increased separately," Maribelle admits.`
 				decline
 			label jamming
@@ -626,7 +626,7 @@ mission "Merchant's Guild Level 7"
 				outfit "Jamming I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 7
-				log "Merchant Levels" "Level 7" "Chose jamming upgrade."
+				log Levels "Merchant" "Level 7: Chose jamming upgrade."
 			`"Jamming? Wow, I never even thought about that before," Maribelle says. "It should alleviate some missile pressure, shouldn't it?"`
 				decline
 			label concealment
@@ -634,7 +634,7 @@ mission "Merchant's Guild Level 7"
 				outfit "Concealment I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 7
-				log "Merchant Levels" "Level 7" "Chose concealment upgrade."
+				log Levels "Merchant" "Level 7: Chose concealment upgrade."
 			`"Ooh, concealment? What are you trying to hide, Captain? An embarassing sixth-grade photo?" Maribelle jokes, giggling.`
 				decline
 
@@ -672,7 +672,7 @@ mission "Merchant's Guild Level 8"
 				outfit "Shields I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 8
-				log "Merchant Levels" "Level 8" "Chose shield upgrade."
+				log Levels "Merchant" "Level 8: Chose shield upgrade."
 			`Maribelle nods in agreement. "More shields can't hurt, can it?" She asks.`
 				goto next
 			label hullcap
@@ -680,7 +680,7 @@ mission "Merchant's Guild Level 8"
 				outfit "Hull I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 8
-				log "Merchant Levels" "Level 8" "Chose hull upgrade."
+				log Levels "Merchant" "Level 8: Chose hull upgrade."
 			`Maribelle nods in agreement. "More hull can't hurt, can it?" She asks.`
 				goto next
 			label cargocap
@@ -688,7 +688,7 @@ mission "Merchant's Guild Level 8"
 				outfit "Cargo I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 8
-				log "Merchant Levels" "Level 8" "Chose cargo upgrade."
+				log Levels "Merchant" "Level 8: Chose cargo upgrade."
 			`"Well, she is rewarding it for merchant work. It does make sense we'd want to do more, faster," Maribelle says.`
 				goto next
 			label fuelcap
@@ -696,7 +696,7 @@ mission "Merchant's Guild Level 8"
 				outfit "Fuel I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 8
-				log "Merchant Levels" "Level 8" "Chose fuel upgrade."
+				log Levels "Merchant" "Level 8: Chose fuel upgrade."
 			`"I didn't even know I could get my fuel capacity increased separately," Maribelle admits.`
 				goto next
 			label jamming
@@ -704,7 +704,7 @@ mission "Merchant's Guild Level 8"
 				outfit "Jamming I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 8
-				log "Merchant Levels" "Level 8" "Chose jamming upgrade."
+				log Levels "Merchant" "Level 8: Chose jamming upgrade."
 			`"Jamming? Wow, I never even thought about that before," Maribelle says. "It should alleviate some missile pressure, shouldn't it?"`
 				goto next
 			label concealment
@@ -712,7 +712,7 @@ mission "Merchant's Guild Level 8"
 				outfit "Concealment I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 8
-				log "Merchant Levels" "Level 8" "Chose concealment upgrade."
+				log Levels "Merchant" "Level 8: Chose concealment upgrade."
 			`"Ooh, concealment? What are you trying to hide, Captain? An embarassing sixth-grade photo?" Maribelle jokes, giggling.`
 				goto next
 
@@ -756,7 +756,7 @@ mission "Merchant's Guild Level 9"
 				outfit "Shields I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 9
-				log "Merchant Levels" "Level 9" "Chose shield upgrade."
+				log Levels "Merchant" "Level 9: Chose shield upgrade."
 			`Maribelle nods in agreement. "More shields can't hurt, can it?" She asks.`
 				decline
 			label hullcap
@@ -764,7 +764,7 @@ mission "Merchant's Guild Level 9"
 				outfit "Hull I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 9
-				log "Merchant Levels" "Level 9" "Chose hull upgrade."
+				log Levels "Merchant" "Level 9: Chose hull upgrade."
 			`Maribelle nods in agreement. "More hull can't hurt, can it?" She asks.`
 				decline
 			label cargocap
@@ -772,7 +772,7 @@ mission "Merchant's Guild Level 9"
 				outfit "Cargo I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 9
-				log "Merchant Levels" "Level 9" "Chose cargo upgrade."
+				log Levels "Merchant" "Level 9: Chose cargo upgrade."
 			`"Well, she is rewarding it for merchant work. It does make sense we'd want to do more, faster," Maribelle says.`
 				decline
 			label fuelcap
@@ -780,7 +780,7 @@ mission "Merchant's Guild Level 9"
 				outfit "Fuel I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 9
-				log "Merchant Levels" "Level 9" "Chose fuel upgrade."
+				log Levels "Merchant" "Level 9: Chose fuel upgrade."
 			`"I didn't even know I could get my fuel capacity increased separately," Maribelle admits.`
 				decline
 			label jamming
@@ -788,7 +788,7 @@ mission "Merchant's Guild Level 9"
 				outfit "Jamming I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 9
-				log "Merchant Levels" "Level 9" "Chose jamming upgrade."
+				log Levels "Merchant" "Level 9: Chose jamming upgrade."
 			`"Jamming? Wow, I never even thought about that before," Maribelle says. "It should alleviate some missile pressure, shouldn't it?"`
 				decline
 			label concealment
@@ -796,7 +796,7 @@ mission "Merchant's Guild Level 9"
 				outfit "Concealment I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 9
-				log "Merchant Levels" "Level 9" "Chose concealment upgrade."
+				log Levels "Merchant" "Level 9: Chose concealment upgrade."
 			`"Ooh, concealment? What are you trying to hide, Captain? An embarassing sixth-grade photo?" Maribelle jokes, giggling.`
 				decline
 
@@ -834,7 +834,7 @@ mission "Merchant's Guild Level 10"
 				outfit "Shields I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 10
-				log "Merchant Levels" "Level 10" "Chose shield upgrade."
+				log Levels "Merchant" "Level 10: Chose shield upgrade."
 			`Maribelle nods in agreement. "More shields can't hurt, can it?" She asks.`
 				goto next
 			label hullcap
@@ -842,7 +842,7 @@ mission "Merchant's Guild Level 10"
 				outfit "Hull I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 10
-				log "Merchant Levels" "Level 10" "Chose hull upgrade."
+				log Levels "Merchant" "Level 10: Chose hull upgrade."
 			`Maribelle nods in agreement. "More hull can't hurt, can it?" She asks.`
 				goto next
 			label cargocap
@@ -850,7 +850,7 @@ mission "Merchant's Guild Level 10"
 				outfit "Cargo I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 10
-				log "Merchant Levels" "Level 10" "Chose cargo upgrade."
+				log Levels "Merchant" "Level 10: Chose cargo upgrade."
 			`"Well, she is rewarding it for merchant work. It does make sense we'd want to do more, faster," Maribelle says.`
 				goto next
 			label fuelcap
@@ -858,7 +858,7 @@ mission "Merchant's Guild Level 10"
 				outfit "Fuel I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 10
-				log "Merchant Levels" "Level 10" "Chose fuel upgrade."
+				log Levels "Merchant" "Level 10: Chose fuel upgrade."
 			`"I didn't even know I could get my fuel capacity increased separately," Maribelle admits.`
 				goto next
 			label jamming
@@ -866,7 +866,7 @@ mission "Merchant's Guild Level 10"
 				outfit "Jamming I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 10
-				log "Merchant Levels" "Level 10" "Chose jamming upgrade."
+				log Levels "Merchant" "Level 10: Chose jamming upgrade."
 			`"Jamming? Wow, I never even thought about that before," Maribelle says. "It should alleviate some missile pressure, shouldn't it?"`
 				goto next
 			label concealment
@@ -874,7 +874,7 @@ mission "Merchant's Guild Level 10"
 				outfit "Concealment I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 10
-				log "Merchant Levels" "Level 10" "Chose concealment upgrade."
+				log Levels "Merchant" "Level 10: Chose concealment upgrade."
 			`"Ooh, concealment? What are you trying to hide, Captain? An embarassing sixth-grade photo?" Maribelle jokes, giggling.`
 				goto next
 
@@ -918,7 +918,7 @@ mission "Merchant's Guild Level 11"
 				outfit "Shields I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 11
-				log "Merchant Levels" "Level 11" "Chose shield upgrade."
+				log Levels "Merchant" "Level 11: Chose shield upgrade."
 			`Maribelle nods in agreement. "More shields can't hurt, can it?" She asks.`
 				decline
 			label hullcap
@@ -926,7 +926,7 @@ mission "Merchant's Guild Level 11"
 				outfit "Hull I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 11
-				log "Merchant Levels" "Level 11" "Chose hull upgrade."
+				log Levels "Merchant" "Level 11: Chose hull upgrade."
 			`Maribelle nods in agreement. "More hull can't hurt, can it?" She asks.`
 				decline
 			label cargocap
@@ -934,7 +934,7 @@ mission "Merchant's Guild Level 11"
 				outfit "Cargo I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 11
-				log "Merchant Levels" "Level 11" "Chose cargo upgrade."
+				log Levels "Merchant" "Level 11: Chose cargo upgrade."
 			`"Well, she is rewarding it for merchant work. It does make sense we'd want to do more, faster," Maribelle says.`
 				decline
 			label fuelcap
@@ -942,7 +942,7 @@ mission "Merchant's Guild Level 11"
 				outfit "Fuel I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 11
-				log "Merchant Levels" "Level 11" "Chose fuel upgrade."
+				log Levels "Merchant" "Level 11: Chose fuel upgrade."
 			`"I didn't even know I could get my fuel capacity increased separately," Maribelle admits.`
 				decline
 			label jamming
@@ -950,7 +950,7 @@ mission "Merchant's Guild Level 11"
 				outfit "Jamming I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 11
-				log "Merchant Levels" "Level 11" "Chose jamming upgrade."
+				log Levels "Merchant" "Level 11: Chose jamming upgrade."
 			`"Jamming? Wow, I never even thought about that before," Maribelle says. "It should alleviate some missile pressure, shouldn't it?"`
 				decline
 			label concealment
@@ -958,7 +958,7 @@ mission "Merchant's Guild Level 11"
 				outfit "Concealment I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 11
-				log "Merchant Levels" "Level 11" "Chose concealment upgrade."
+				log Levels "Merchant" "Level 11: Chose concealment upgrade."
 			`"Ooh, concealment? What are you trying to hide, Captain? An embarassing sixth-grade photo?" Maribelle jokes, giggling.`
 				decline
 
@@ -996,7 +996,7 @@ mission "Merchant's Guild Level 12"
 				outfit "Shields I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 12
-				log "Merchant Levels" "Level 12" "Chose shield upgrade."
+				log Levels "Merchant" "Level 12: Chose shield upgrade."
 			`Maribelle nods in agreement. "More shields can't hurt, can it?" She asks.`
 				goto next
 			label hullcap
@@ -1004,7 +1004,7 @@ mission "Merchant's Guild Level 12"
 				outfit "Hull I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 12
-				log "Merchant Levels" "Level 12" "Chose hull upgrade."
+				log Levels "Merchant" "Level 12: Chose hull upgrade."
 			`Maribelle nods in agreement. "More hull can't hurt, can it?" She asks.`
 				goto next
 			label cargocap
@@ -1012,7 +1012,7 @@ mission "Merchant's Guild Level 12"
 				outfit "Cargo I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 12
-				log "Merchant Levels" "Level 12" "Chose cargo upgrade."
+				log Levels "Merchant" "Level 12: Chose cargo upgrade."
 			`"Well, she is rewarding it for merchant work. It does make sense we'd want to do more, faster," Maribelle says.`
 				goto next
 			label fuelcap
@@ -1020,7 +1020,7 @@ mission "Merchant's Guild Level 12"
 				outfit "Fuel I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 12
-				log "Merchant Levels" "Level 12" "Chose fuel upgrade."
+				log Levels "Merchant" "Level 12: Chose fuel upgrade."
 			`"I didn't even know I could get my fuel capacity increased separately," Maribelle admits.`
 				goto next
 			label jamming
@@ -1028,7 +1028,7 @@ mission "Merchant's Guild Level 12"
 				outfit "Jamming I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 12
-				log "Merchant Levels" "Level 12" "Chose jamming upgrade."
+				log Levels "Merchant" "Level 12: Chose jamming upgrade."
 			`"Jamming? Wow, I never even thought about that before," Maribelle says. "It should alleviate some missile pressure, shouldn't it?"`
 				goto next
 			label concealment
@@ -1036,7 +1036,7 @@ mission "Merchant's Guild Level 12"
 				outfit "Concealment I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 12
-				log "Merchant Levels" "Level 12" "Chose concealment upgrade."
+				log Levels "Merchant" "Level 12: Chose concealment upgrade."
 			`"Ooh, concealment? What are you trying to hide, Captain? An embarassing sixth-grade photo?" Maribelle jokes, giggling.`
 				goto next
 
@@ -1080,7 +1080,7 @@ mission "Merchant's Guild Level 13"
 				outfit "Shields I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 13
-				log "Merchant Levels" "Level 13" "Chose shield upgrade."
+				log Levels "Merchant" "Level 13: Chose shield upgrade."
 			`Maribelle nods in agreement. "More shields can't hurt, can it?" She asks.`
 				decline
 			label hullcap
@@ -1088,7 +1088,7 @@ mission "Merchant's Guild Level 13"
 				outfit "Hull I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 13
-				log "Merchant Levels" "Level 13" "Chose hull upgrade."
+				log Levels "Merchant" "Level 13: Chose hull upgrade."
 			`Maribelle nods in agreement. "More hull can't hurt, can it?" She asks.`
 				decline
 			label cargocap
@@ -1096,7 +1096,7 @@ mission "Merchant's Guild Level 13"
 				outfit "Cargo I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 13
-				log "Merchant Levels" "Level 13" "Chose cargo upgrade."
+				log Levels "Merchant" "Level 13: Chose cargo upgrade."
 			`"Well, she is rewarding it for merchant work. It does make sense we'd want to do more, faster," Maribelle says.`
 				decline
 			label fuelcap
@@ -1104,7 +1104,7 @@ mission "Merchant's Guild Level 13"
 				outfit "Fuel I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 13
-				log "Merchant Levels" "Level 13" "Chose fuel upgrade."
+				log Levels "Merchant" "Level 13: Chose fuel upgrade."
 			`"I didn't even know I could get my fuel capacity increased separately," Maribelle admits.`
 				decline
 			label jamming
@@ -1112,7 +1112,7 @@ mission "Merchant's Guild Level 13"
 				outfit "Jamming I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 13
-				log "Merchant Levels" "Level 13" "Chose jamming upgrade."
+				log Levels "Merchant" "Level 13: Chose jamming upgrade."
 			`"Jamming? Wow, I never even thought about that before," Maribelle says. "It should alleviate some missile pressure, shouldn't it?"`
 				decline
 			label concealment
@@ -1120,7 +1120,7 @@ mission "Merchant's Guild Level 13"
 				outfit "Concealment I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 13
-				log "Merchant Levels" "Level 13" "Chose concealment upgrade."
+				log Levels "Merchant" "Level 13: Chose concealment upgrade."
 			`"Ooh, concealment? What are you trying to hide, Captain? An embarassing sixth-grade photo?" Maribelle jokes, giggling.`
 				decline
 
@@ -1158,7 +1158,7 @@ mission "Merchant's Guild Level 14"
 				outfit "Shields I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 14
-				log "Merchant Levels" "Level 14" "Chose shield upgrade."
+				log Levels "Merchant" "Level 14: Chose shield upgrade."
 			`Maribelle nods in agreement. "More shields can't hurt, can it?" She asks.`
 				goto next
 			label hullcap
@@ -1166,7 +1166,7 @@ mission "Merchant's Guild Level 14"
 				outfit "Hull I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 14
-				log "Merchant Levels" "Level 14" "Chose hull upgrade."
+				log Levels "Merchant" "Level 14: Chose hull upgrade."
 			`Maribelle nods in agreement. "More hull can't hurt, can it?" She asks.`
 				goto next
 			label cargocap
@@ -1174,7 +1174,7 @@ mission "Merchant's Guild Level 14"
 				outfit "Cargo I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 14
-				log "Merchant Levels" "Level 14" "Chose cargo upgrade."
+				log Levels "Merchant" "Level 14: Chose cargo upgrade."
 			`"Well, she is rewarding it for merchant work. It does make sense we'd want to do more, faster," Maribelle says.`
 				goto next
 			label fuelcap
@@ -1182,7 +1182,7 @@ mission "Merchant's Guild Level 14"
 				outfit "Fuel I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 14
-				log "Merchant Levels" "Level 14" "Chose fuel upgrade."
+				log Levels "Merchant" "Level 14: Chose fuel upgrade."
 			`"I didn't even know I could get my fuel capacity increased separately," Maribelle admits.`
 				goto next
 			label jamming
@@ -1190,7 +1190,7 @@ mission "Merchant's Guild Level 14"
 				outfit "Jamming I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 14
-				log "Merchant Levels" "Level 14" "Chose jamming upgrade."
+				log Levels "Merchant" "Level 14: Chose jamming upgrade."
 			`"Jamming? Wow, I never even thought about that before," Maribelle says. "It should alleviate some missile pressure, shouldn't it?"`
 				goto next
 			label concealment
@@ -1198,7 +1198,7 @@ mission "Merchant's Guild Level 14"
 				outfit "Concealment I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 14
-				log "Merchant Levels" "Level 14" "Chose concealment upgrade."
+				log Levels "Merchant" "Level 14: Chose concealment upgrade."
 			`"Ooh, concealment? What are you trying to hide, Captain? An embarassing sixth-grade photo?" Maribelle jokes, giggling.`
 				goto next
 
@@ -1242,7 +1242,7 @@ mission "Merchant's Guild Level 15"
 				outfit "Shields I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 15
-				log "Merchant Levels" "Level 15" "Chose shield upgrade."
+				log Levels "Merchant" "Level 15: Chose shield upgrade."
 			`Maribelle nods in agreement. "More shields can't hurt, can it?" She asks.`
 				decline
 			label hullcap
@@ -1250,7 +1250,7 @@ mission "Merchant's Guild Level 15"
 				outfit "Hull I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 15
-				log "Merchant Levels" "Level 15" "Chose hull upgrade."
+				log Levels "Merchant" "Level 15: Chose hull upgrade."
 			`Maribelle nods in agreement. "More hull can't hurt, can it?" She asks.`
 				decline
 			label cargocap
@@ -1258,7 +1258,7 @@ mission "Merchant's Guild Level 15"
 				outfit "Cargo I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 15
-				log "Merchant Levels" "Level 15" "Chose cargo upgrade."
+				log Levels "Merchant" "Level 15: Chose cargo upgrade."
 			`"Well, she is rewarding it for merchant work. It does make sense we'd want to do more, faster," Maribelle says.`
 				decline
 			label fuelcap
@@ -1266,7 +1266,7 @@ mission "Merchant's Guild Level 15"
 				outfit "Fuel I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 15
-				log "Merchant Levels" "Level 15" "Chose fuel upgrade."
+				log Levels "Merchant" "Level 15: Chose fuel upgrade."
 			`"I didn't even know I could get my fuel capacity increased separately," Maribelle admits.`
 				decline
 			label jamming
@@ -1274,7 +1274,7 @@ mission "Merchant's Guild Level 15"
 				outfit "Jamming I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 15
-				log "Merchant Levels" "Level 15" "Chose jamming upgrade."
+				log Levels "Merchant" "Level 15: Chose jamming upgrade."
 			`"Jamming? Wow, I never even thought about that before," Maribelle says. "It should alleviate some missile pressure, shouldn't it?"`
 				decline
 			label concealment
@@ -1282,7 +1282,7 @@ mission "Merchant's Guild Level 15"
 				outfit "Concealment I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 15
-				log "Merchant Levels" "Level 15" "Chose concealment upgrade."
+				log Levels "Merchant" "Level 15: Chose concealment upgrade."
 			`"Ooh, concealment? What are you trying to hide, Captain? An embarassing sixth-grade photo?" Maribelle jokes, giggling.`
 				decline
 
@@ -1320,7 +1320,7 @@ mission "Merchant's Guild Level 16"
 				outfit "Shields I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 16
-				log "Merchant Levels" "Level 16" "Chose shield upgrade."
+				log Levels "Merchant" "Level 16: Chose shield upgrade."
 			`Maribelle nods in agreement. "More shields can't hurt, can it?" She asks.`
 				goto next
 			label hullcap
@@ -1328,7 +1328,7 @@ mission "Merchant's Guild Level 16"
 				outfit "Hull I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 16
-				log "Merchant Levels" "Level 16" "Chose hull upgrade."
+				log Levels "Merchant" "Level 16: Chose hull upgrade."
 			`Maribelle nods in agreement. "More hull can't hurt, can it?" She asks.`
 				goto next
 			label cargocap
@@ -1336,7 +1336,7 @@ mission "Merchant's Guild Level 16"
 				outfit "Cargo I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 16
-				log "Merchant Levels" "Level 16" "Chose cargo upgrade."
+				log Levels "Merchant" "Level 16: Chose cargo upgrade."
 			`"Well, she is rewarding it for merchant work. It does make sense we'd want to do more, faster," Maribelle says.`
 				goto next
 			label fuelcap
@@ -1344,7 +1344,7 @@ mission "Merchant's Guild Level 16"
 				outfit "Fuel I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 16
-				log "Merchant Levels" "Level 16" "Chose fuel upgrade."
+				log Levels "Merchant" "Level 16: Chose fuel upgrade."
 			`"I didn't even know I could get my fuel capacity increased separately," Maribelle admits.`
 				goto next
 			label jamming
@@ -1352,7 +1352,7 @@ mission "Merchant's Guild Level 16"
 				outfit "Jamming I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 16
-				log "Merchant Levels" "Level 16" "Chose jamming upgrade."
+				log Levels "Merchant" "Level 16: Chose jamming upgrade."
 			`"Jamming? Wow, I never even thought about that before," Maribelle says. "It should alleviate some missile pressure, shouldn't it?"`
 				goto next
 			label concealment
@@ -1360,7 +1360,7 @@ mission "Merchant's Guild Level 16"
 				outfit "Concealment I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 16
-				log "Merchant Levels" "Level 16" "Chose concealment upgrade."
+				log Levels "Merchant" "Level 16: Chose concealment upgrade."
 			`"Ooh, concealment? What are you trying to hide, Captain? An embarassing sixth-grade photo?" Maribelle jokes, giggling.`
 				goto next
 
@@ -1404,7 +1404,7 @@ mission "Merchant's Guild Level 17"
 				outfit "Shields I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 17
-				log "Merchant Levels" "Level 17" "Chose shield upgrade."
+				log Levels "Merchant" "Level 17: Chose shield upgrade."
 			`Maribelle nods in agreement. "More shields can't hurt, can it?" She asks.`
 				decline
 			label hullcap
@@ -1412,7 +1412,7 @@ mission "Merchant's Guild Level 17"
 				outfit "Hull I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 17
-				log "Merchant Levels" "Level 17" "Chose hull upgrade."
+				log Levels "Merchant" "Level 17: Chose hull upgrade."
 			`Maribelle nods in agreement. "More hull can't hurt, can it?" She asks.`
 				decline
 			label cargocap
@@ -1420,7 +1420,7 @@ mission "Merchant's Guild Level 17"
 				outfit "Cargo I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 17
-				log "Merchant Levels" "Level 17" "Chose cargo upgrade."
+				log Levels "Merchant" "Level 17: Chose cargo upgrade."
 			`"Well, she is rewarding it for merchant work. It does make sense we'd want to do more, faster," Maribelle says.`
 				decline
 			label fuelcap
@@ -1428,7 +1428,7 @@ mission "Merchant's Guild Level 17"
 				outfit "Fuel I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 17
-				log "Merchant Levels" "Level 17" "Chose fuel upgrade."
+				log Levels "Merchant" "Level 17: Chose fuel upgrade."
 			`"I didn't even know I could get my fuel capacity increased separately," Maribelle admits.`
 				decline
 			label jamming
@@ -1436,7 +1436,7 @@ mission "Merchant's Guild Level 17"
 				outfit "Jamming I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 17
-				log "Merchant Levels" "Level 17" "Chose jamming upgrade."
+				log Levels "Merchant" "Level 17: Chose jamming upgrade."
 			`"Jamming? Wow, I never even thought about that before," Maribelle says. "It should alleviate some missile pressure, shouldn't it?"`
 				decline
 			label concealment
@@ -1444,7 +1444,7 @@ mission "Merchant's Guild Level 17"
 				outfit "Concealment I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 17
-				log "Merchant Levels" "Level 17" "Chose concealment upgrade."
+				log Levels "Merchant" "Level 17: Chose concealment upgrade."
 			`"Ooh, concealment? What are you trying to hide, Captain? An embarassing sixth-grade photo?" Maribelle jokes, giggling.`
 				decline
 
@@ -1482,7 +1482,7 @@ mission "Merchant's Guild Level 18"
 				outfit "Shields I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 18
-				log "Merchant Levels" "Level 18" "Chose shield upgrade."
+				log Levels "Merchant" "Level 18: Chose shield upgrade."
 			`Maribelle nods in agreement. "More shields can't hurt, can it?" She asks.`
 				goto next
 			label hullcap
@@ -1490,7 +1490,7 @@ mission "Merchant's Guild Level 18"
 				outfit "Hull I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 18
-				log "Merchant Levels" "Level 18" "Chose hull upgrade."
+				log Levels "Merchant" "Level 18: Chose hull upgrade."
 			`Maribelle nods in agreement. "More hull can't hurt, can it?" She asks.`
 				goto next
 			label cargocap
@@ -1498,7 +1498,7 @@ mission "Merchant's Guild Level 18"
 				outfit "Cargo I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 18
-				log "Merchant Levels" "Level 18" "Chose cargo upgrade."
+				log Levels "Merchant" "Level 18: Chose cargo upgrade."
 			`"Well, she is rewarding it for merchant work. It does make sense we'd want to do more, faster," Maribelle says.`
 				goto next
 			label fuelcap
@@ -1506,7 +1506,7 @@ mission "Merchant's Guild Level 18"
 				outfit "Fuel I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 18
-				log "Merchant Levels" "Level 18" "Chose fuel upgrade."
+				log Levels "Merchant" "Level 18: Chose fuel upgrade."
 			`"I didn't even know I could get my fuel capacity increased separately," Maribelle admits.`
 				goto next
 			label jamming
@@ -1514,7 +1514,7 @@ mission "Merchant's Guild Level 18"
 				outfit "Jamming I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 18
-				log "Merchant Levels" "Level 18" "Chose jamming upgrade."
+				log Levels "Merchant" "Level 18: Chose jamming upgrade."
 			`"Jamming? Wow, I never even thought about that before," Maribelle says. "It should alleviate some missile pressure, shouldn't it?"`
 				goto next
 			label concealment
@@ -1522,7 +1522,7 @@ mission "Merchant's Guild Level 18"
 				outfit "Concealment I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 18
-				log "Merchant Levels" "Level 18" "Chose concealment upgrade."
+				log Levels "Merchant" "Level 18: Chose concealment upgrade."
 			`"Ooh, concealment? What are you trying to hide, Captain? An embarassing sixth-grade photo?" Maribelle jokes, giggling.`
 				goto next
 
@@ -1566,7 +1566,7 @@ mission "Merchant's Guild Level 19"
 				outfit "Shields I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 19
-				log "Merchant Levels" "Level 19" "Chose shield upgrade."
+				log Levels "Merchant" "Level 19: Chose shield upgrade."
 			`Maribelle nods in agreement. "More shields can't hurt, can it?" She asks.`
 				decline
 			label hullcap
@@ -1574,7 +1574,7 @@ mission "Merchant's Guild Level 19"
 				outfit "Hull I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 19
-				log "Merchant Levels" "Level 19" "Chose hull upgrade."
+				log Levels "Merchant" "Level 19: Chose hull upgrade."
 			`Maribelle nods in agreement. "More hull can't hurt, can it?" She asks.`
 				decline
 			label cargocap
@@ -1582,7 +1582,7 @@ mission "Merchant's Guild Level 19"
 				outfit "Cargo I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 19
-				log "Merchant Levels" "Level 19" "Chose cargo upgrade."
+				log Levels "Merchant" "Level 19: Chose cargo upgrade."
 			`"Well, she is rewarding it for merchant work. It does make sense we'd want to do more, faster," Maribelle says.`
 				decline
 			label fuelcap
@@ -1590,7 +1590,7 @@ mission "Merchant's Guild Level 19"
 				outfit "Fuel I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 19
-				log "Merchant Levels" "Level 19" "Chose fuel upgrade."
+				log Levels "Merchant" "Level 19: Chose fuel upgrade."
 			`"I didn't even know I could get my fuel capacity increased separately," Maribelle admits.`
 				decline
 			label jamming
@@ -1598,7 +1598,7 @@ mission "Merchant's Guild Level 19"
 				outfit "Jamming I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 19
-				log "Merchant Levels" "Level 19" "Chose jamming upgrade."
+				log Levels "Merchant" "Level 19: Chose jamming upgrade."
 			`"Jamming? Wow, I never even thought about that before," Maribelle says. "It should alleviate some missile pressure, shouldn't it?"`
 				decline
 			label concealment
@@ -1606,7 +1606,7 @@ mission "Merchant's Guild Level 19"
 				outfit "Concealment I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 19
-				log "Merchant Levels" "Level 19" "Chose concealment upgrade."
+				log Levels "Merchant" "Level 19: Chose concealment upgrade."
 			`"Ooh, concealment? What are you trying to hide, Captain? An embarassing sixth-grade photo?" Maribelle jokes, giggling.`
 				decline
 
@@ -1644,7 +1644,7 @@ mission "Merchant's Guild Level 20"
 				outfit "Shields I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 20
-				log "Merchant Levels" "Level 20" "Chose shield upgrade."
+				log Levels "Merchant" "Level 20: Chose shield upgrade."
 			`Maribelle nods in agreement. "More shields can't hurt, can it?" She asks.`
 				goto next
 			label hullcap
@@ -1652,7 +1652,7 @@ mission "Merchant's Guild Level 20"
 				outfit "Hull I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 20
-				log "Merchant Levels" "Level 20" "Chose hull upgrade."
+				log Levels "Merchant" "Level 20: Chose hull upgrade."
 			`Maribelle nods in agreement. "More hull can't hurt, can it?" She asks.`
 				goto next
 			label cargocap
@@ -1660,7 +1660,7 @@ mission "Merchant's Guild Level 20"
 				outfit "Cargo I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 20
-				log "Merchant Levels" "Level 20" "Chose cargo upgrade."
+				log Levels "Merchant" "Level 20: Chose cargo upgrade."
 			`"Well, she is rewarding it for merchant work. It does make sense we'd want to do more, faster," Maribelle says.`
 				goto next
 			label fuelcap
@@ -1668,7 +1668,7 @@ mission "Merchant's Guild Level 20"
 				outfit "Fuel I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 20
-				log "Merchant Levels" "Level 20" "Chose fuel upgrade."
+				log Levels "Merchant" "Level 20: Chose fuel upgrade."
 			`"I didn't even know I could get my fuel capacity increased separately," Maribelle admits.`
 				goto next
 			label jamming
@@ -1676,7 +1676,7 @@ mission "Merchant's Guild Level 20"
 				outfit "Jamming I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 20
-				log "Merchant Levels" "Level 20" "Chose jamming upgrade."
+				log Levels "Merchant" "Level 20: Chose jamming upgrade."
 			`"Jamming? Wow, I never even thought about that before," Maribelle says. "It should alleviate some missile pressure, shouldn't it?"`
 				goto next
 			label concealment
@@ -1684,7 +1684,7 @@ mission "Merchant's Guild Level 20"
 				outfit "Concealment I (Merchant)" 1
 				outfit "Basal Level I (Merchant)" 1
 				"merchant's guild level" = 20
-				log "Merchant Levels" "Level 20" "Chose concealment upgrade."
+				log Levels "Merchant" "Level 20: Chose concealment upgrade."
 			`"Ooh, concealment? What are you trying to hide, Captain? An embarassing sixth-grade photo?" Maribelle jokes, giggling.`
 				goto next
 

--- a/data/merchantsguild/merchantlevels21-40.txt
+++ b/data/merchantsguild/merchantlevels21-40.txt
@@ -109,7 +109,7 @@ mission "Merchant's Guild Level 21"
 				outfit "Shields II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 21
-				log "Merchant Levels" "Level 21" "Chose shield upgrade."
+				log Levels "Merchant" "Level 21: Chose shield upgrade."
 			`Maribelle nods in agreement. "More shields can't hurt, can it?" She asks.`
 				decline
 			label hullcap
@@ -117,7 +117,7 @@ mission "Merchant's Guild Level 21"
 				outfit "Hull II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 21
-				log "Merchant Levels" "Level 21" "Chose hull upgrade."
+				log Levels "Merchant" "Level 21: Chose hull upgrade."
 			`Maribelle nods in agreement. "More hull can't hurt, can it?" She asks.`
 				decline
 			label cargocap
@@ -125,7 +125,7 @@ mission "Merchant's Guild Level 21"
 				outfit "Cargo II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 21
-				log "Merchant Levels" "Level 21" "Chose cargo upgrade."
+				log Levels "Merchant" "Level 21: Chose cargo upgrade."
 			`"Well, she is rewarding it for merchant work. It does make sense we'd want to do more, faster," Maribelle says.`
 				decline
 			label fuelcap
@@ -133,7 +133,7 @@ mission "Merchant's Guild Level 21"
 				outfit "Fuel II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 21
-				log "Merchant Levels" "Level 21" "Chose fuel upgrade."
+				log Levels "Merchant" "Level 21: Chose fuel upgrade."
 			`"I didn't even know I could get my fuel capacity increased separately," Maribelle admits.`
 				decline
 			label jamming
@@ -141,7 +141,7 @@ mission "Merchant's Guild Level 21"
 				outfit "Jamming II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 21
-				log "Merchant Levels" "Level 21" "Chose jamming upgrade."
+				log Levels "Merchant" "Level 21: Chose jamming upgrade."
 			`"Jamming? Wow, I never even thought about that before," Maribelle says. "It should alleviate some missile pressure, shouldn't it?"`
 				decline
 			label concealment
@@ -149,7 +149,7 @@ mission "Merchant's Guild Level 21"
 				outfit "Concealment II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 21
-				log "Merchant Levels" "Level 21" "Chose concealment upgrade."
+				log Levels "Merchant" "Level 21: Chose concealment upgrade."
 			`"Ooh, concealment? What are you trying to hide, Captain? An embarassing sixth-grade photo?" Maribelle jokes, giggling.`
 				decline
 
@@ -187,7 +187,7 @@ mission "Merchant's Guild Level 22"
 				outfit "Shields II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 22
-				log "Merchant Levels" "Level 22" "Chose shield upgrade."
+				log Levels "Merchant" "Level 22: Chose shield upgrade."
 			`Maribelle nods in agreement. "More shields can't hurt, can it?" She asks.`
 				goto next
 			label hullcap
@@ -195,7 +195,7 @@ mission "Merchant's Guild Level 22"
 				outfit "Hull II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 22
-				log "Merchant Levels" "Level 22" "Chose hull upgrade."
+				log Levels "Merchant" "Level 22: Chose hull upgrade."
 			`Maribelle nods in agreement. "More hull can't hurt, can it?" She asks.`
 				goto next
 			label cargocap
@@ -203,7 +203,7 @@ mission "Merchant's Guild Level 22"
 				outfit "Cargo II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 22
-				log "Merchant Levels" "Level 22" "Chose cargo upgrade."
+				log Levels "Merchant" "Level 22: Chose cargo upgrade."
 			`"Well, she is rewarding it for merchant work. It does make sense we'd want to do more, faster," Maribelle says.`
 				goto next
 			label fuelcap
@@ -211,7 +211,7 @@ mission "Merchant's Guild Level 22"
 				outfit "Fuel II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 22
-				log "Merchant Levels" "Level 22" "Chose fuel upgrade."
+				log Levels "Merchant" "Level 22: Chose fuel upgrade."
 			`"I didn't even know I could get my fuel capacity increased separately," Maribelle admits.`
 				goto next
 			label jamming
@@ -219,7 +219,7 @@ mission "Merchant's Guild Level 22"
 				outfit "Jamming II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 22
-				log "Merchant Levels" "Level 22" "Chose jamming upgrade."
+				log Levels "Merchant" "Level 22: Chose jamming upgrade."
 			`"Jamming? Wow, I never even thought about that before," Maribelle says. "It should alleviate some missile pressure, shouldn't it?"`
 				goto next
 			label concealment
@@ -227,7 +227,7 @@ mission "Merchant's Guild Level 22"
 				outfit "Concealment II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 22
-				log "Merchant Levels" "Level 22" "Chose concealment upgrade."
+				log Levels "Merchant" "Level 22: Chose concealment upgrade."
 			`"Ooh, concealment? What are you trying to hide, Captain? An embarassing sixth-grade photo?" Maribelle jokes, giggling.`
 				goto next
 
@@ -271,7 +271,7 @@ mission "Merchant's Guild Level 23"
 				outfit "Shields II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 23
-				log "Merchant Levels" "Level 23" "Chose shield upgrade."
+				log Levels "Merchant" "Level 23: Chose shield upgrade."
 			`Maribelle nods in agreement. "More shields can't hurt, can it?" She asks.`
 				decline
 			label hullcap
@@ -279,7 +279,7 @@ mission "Merchant's Guild Level 23"
 				outfit "Hull II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 23
-				log "Merchant Levels" "Level 23" "Chose hull upgrade."
+				log Levels "Merchant" "Level 23: Chose hull upgrade."
 			`Maribelle nods in agreement. "More hull can't hurt, can it?" She asks.`
 				decline
 			label cargocap
@@ -287,7 +287,7 @@ mission "Merchant's Guild Level 23"
 				outfit "Cargo II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 23
-				log "Merchant Levels" "Level 23" "Chose cargo upgrade."
+				log Levels "Merchant" "Level 23: Chose cargo upgrade."
 			`"Well, she is rewarding it for merchant work. It does make sense we'd want to do more, faster," Maribelle says.`
 				decline
 			label fuelcap
@@ -295,7 +295,7 @@ mission "Merchant's Guild Level 23"
 				outfit "Fuel II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 23
-				log "Merchant Levels" "Level 23" "Chose fuel upgrade."
+				log Levels "Merchant" "Level 23: Chose fuel upgrade."
 			`"I didn't even know I could get my fuel capacity increased separately," Maribelle admits.`
 				decline
 			label jamming
@@ -303,7 +303,7 @@ mission "Merchant's Guild Level 23"
 				outfit "Jamming II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 23
-				log "Merchant Levels" "Level 23" "Chose jamming upgrade."
+				log Levels "Merchant" "Level 23: Chose jamming upgrade."
 			`"Jamming? Wow, I never even thought about that before," Maribelle says. "It should alleviate some missile pressure, shouldn't it?"`
 				decline
 			label concealment
@@ -311,7 +311,7 @@ mission "Merchant's Guild Level 23"
 				outfit "Concealment II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 23
-				log "Merchant Levels" "Level 23" "Chose concealment upgrade."
+				log Levels "Merchant" "Level 23: Chose concealment upgrade."
 			`"Ooh, concealment? What are you trying to hide, Captain? An embarassing sixth-grade photo?" Maribelle jokes, giggling.`
 				decline
 
@@ -349,7 +349,7 @@ mission "Merchant's Guild Level 24"
 				outfit "Shields II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 24
-				log "Merchant Levels" "Level 24" "Chose shield upgrade."
+				log Levels "Merchant" "Level 24: Chose shield upgrade."
 			`Maribelle nods in agreement. "More shields can't hurt, can it?" She asks.`
 				goto next
 			label hullcap
@@ -357,7 +357,7 @@ mission "Merchant's Guild Level 24"
 				outfit "Hull II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 24
-				log "Merchant Levels" "Level 24" "Chose hull upgrade."
+				log Levels "Merchant" "Level 24: Chose hull upgrade."
 			`Maribelle nods in agreement. "More hull can't hurt, can it?" She asks.`
 				goto next
 			label cargocap
@@ -365,7 +365,7 @@ mission "Merchant's Guild Level 24"
 				outfit "Cargo II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 24
-				log "Merchant Levels" "Level 24" "Chose cargo upgrade."
+				log Levels "Merchant" "Level 24: Chose cargo upgrade."
 			`"Well, she is rewarding it for merchant work. It does make sense we'd want to do more, faster," Maribelle says.`
 				goto next
 			label fuelcap
@@ -373,7 +373,7 @@ mission "Merchant's Guild Level 24"
 				outfit "Fuel II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 24
-				log "Merchant Levels" "Level 24" "Chose fuel upgrade."
+				log Levels "Merchant" "Level 24: Chose fuel upgrade."
 			`"I didn't even know I could get my fuel capacity increased separately," Maribelle admits.`
 				goto next
 			label jamming
@@ -381,7 +381,7 @@ mission "Merchant's Guild Level 24"
 				outfit "Jamming II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 24
-				log "Merchant Levels" "Level 24" "Chose jamming upgrade."
+				log Levels "Merchant" "Level 24: Chose jamming upgrade."
 			`"Jamming? Wow, I never even thought about that before," Maribelle says. "It should alleviate some missile pressure, shouldn't it?"`
 				goto next
 			label concealment
@@ -389,7 +389,7 @@ mission "Merchant's Guild Level 24"
 				outfit "Concealment II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 24
-				log "Merchant Levels" "Level 24" "Chose concealment upgrade."
+				log Levels "Merchant" "Level 24: Chose concealment upgrade."
 			`"Ooh, concealment? What are you trying to hide, Captain? An embarassing sixth-grade photo?" Maribelle jokes, giggling.`
 				goto next
 
@@ -433,7 +433,7 @@ mission "Merchant's Guild Level 25"
 				outfit "Shields II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 25
-				log "Merchant Levels" "Level 25" "Chose shield upgrade."
+				log Levels "Merchant" "Level 25: Chose shield upgrade."
 			`Maribelle nods in agreement. "More shields can't hurt, can it?" She asks.`
 				decline
 			label hullcap
@@ -441,7 +441,7 @@ mission "Merchant's Guild Level 25"
 				outfit "Hull II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 25
-				log "Merchant Levels" "Level 25" "Chose hull upgrade."
+				log Levels "Merchant" "Level 25: Chose hull upgrade."
 			`Maribelle nods in agreement. "More hull can't hurt, can it?" She asks.`
 				decline
 			label cargocap
@@ -449,7 +449,7 @@ mission "Merchant's Guild Level 25"
 				outfit "Cargo II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 25
-				log "Merchant Levels" "Level 25" "Chose cargo upgrade."
+				log Levels "Merchant" "Level 25: Chose cargo upgrade."
 			`"Well, she is rewarding it for merchant work. It does make sense we'd want to do more, faster," Maribelle says.`
 				decline
 			label fuelcap
@@ -457,7 +457,7 @@ mission "Merchant's Guild Level 25"
 				outfit "Fuel II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 25
-				log "Merchant Levels" "Level 25" "Chose fuel upgrade."
+				log Levels "Merchant" "Level 25: Chose fuel upgrade."
 			`"I didn't even know I could get my fuel capacity increased separately," Maribelle admits.`
 				decline
 			label jamming
@@ -465,7 +465,7 @@ mission "Merchant's Guild Level 25"
 				outfit "Jamming II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 25
-				log "Merchant Levels" "Level 25" "Chose jamming upgrade."
+				log Levels "Merchant" "Level 25: Chose jamming upgrade."
 			`"Jamming? Wow, I never even thought about that before," Maribelle says. "It should alleviate some missile pressure, shouldn't it?"`
 				decline
 			label concealment
@@ -473,7 +473,7 @@ mission "Merchant's Guild Level 25"
 				outfit "Concealment II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 25
-				log "Merchant Levels" "Level 25" "Chose concealment upgrade."
+				log Levels "Merchant" "Level 25: Chose concealment upgrade."
 			`"Ooh, concealment? What are you trying to hide, Captain? An embarassing sixth-grade photo?" Maribelle jokes, giggling.`
 				decline
 
@@ -511,7 +511,7 @@ mission "Merchant's Guild Level 26"
 				outfit "Shields II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 26
-				log "Merchant Levels" "Level 26" "Chose shield upgrade."
+				log Levels "Merchant" "Level 26: Chose shield upgrade."
 			`Maribelle nods in agreement. "More shields can't hurt, can it?" She asks.`
 				goto next
 			label hullcap
@@ -519,7 +519,7 @@ mission "Merchant's Guild Level 26"
 				outfit "Hull II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 26
-				log "Merchant Levels" "Level 26" "Chose hull upgrade."
+				log Levels "Merchant" "Level 26: Chose hull upgrade."
 			`Maribelle nods in agreement. "More hull can't hurt, can it?" She asks.`
 				goto next
 			label cargocap
@@ -527,7 +527,7 @@ mission "Merchant's Guild Level 26"
 				outfit "Cargo II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 26
-				log "Merchant Levels" "Level 26" "Chose cargo upgrade."
+				log Levels "Merchant" "Level 26: Chose cargo upgrade."
 			`"Well, she is rewarding it for merchant work. It does make sense we'd want to do more, faster," Maribelle says.`
 				goto next
 			label fuelcap
@@ -535,7 +535,7 @@ mission "Merchant's Guild Level 26"
 				outfit "Fuel II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 26
-				log "Merchant Levels" "Level 26" "Chose fuel upgrade."
+				log Levels "Merchant" "Level 26: Chose fuel upgrade."
 			`"I didn't even know I could get my fuel capacity increased separately," Maribelle admits.`
 				goto next
 			label jamming
@@ -543,7 +543,7 @@ mission "Merchant's Guild Level 26"
 				outfit "Jamming II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 26
-				log "Merchant Levels" "Level 26" "Chose jamming upgrade."
+				log Levels "Merchant" "Level 26: Chose jamming upgrade."
 			`"Jamming? Wow, I never even thought about that before," Maribelle says. "It should alleviate some missile pressure, shouldn't it?"`
 				goto next
 			label concealment
@@ -551,7 +551,7 @@ mission "Merchant's Guild Level 26"
 				outfit "Concealment II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 26
-				log "Merchant Levels" "Level 26" "Chose concealment upgrade."
+				log Levels "Merchant" "Level 26: Chose concealment upgrade."
 			`"Ooh, concealment? What are you trying to hide, Captain? An embarassing sixth-grade photo?" Maribelle jokes, giggling.`
 				goto next
 
@@ -595,7 +595,7 @@ mission "Merchant's Guild Level 27"
 				outfit "Shields II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 27
-				log "Merchant Levels" "Level 27" "Chose shield upgrade."
+				log Levels "Merchant" "Level 27: Chose shield upgrade."
 			`Maribelle nods in agreement. "More shields can't hurt, can it?" She asks.`
 				decline
 			label hullcap
@@ -603,7 +603,7 @@ mission "Merchant's Guild Level 27"
 				outfit "Hull II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 27
-				log "Merchant Levels" "Level 27" "Chose hull upgrade."
+				log Levels "Merchant" "Level 27: Chose hull upgrade."
 			`Maribelle nods in agreement. "More hull can't hurt, can it?" She asks.`
 				decline
 			label cargocap
@@ -611,7 +611,7 @@ mission "Merchant's Guild Level 27"
 				outfit "Cargo II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 27
-				log "Merchant Levels" "Level 27" "Chose cargo upgrade."
+				log Levels "Merchant" "Level 27: Chose cargo upgrade."
 			`"Well, she is rewarding it for merchant work. It does make sense we'd want to do more, faster," Maribelle says.`
 				decline
 			label fuelcap
@@ -619,7 +619,7 @@ mission "Merchant's Guild Level 27"
 				outfit "Fuel II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 27
-				log "Merchant Levels" "Level 27" "Chose fuel upgrade."
+				log Levels "Merchant" "Level 27: Chose fuel upgrade."
 			`"I didn't even know I could get my fuel capacity increased separately," Maribelle admits.`
 				decline
 			label jamming
@@ -627,7 +627,7 @@ mission "Merchant's Guild Level 27"
 				outfit "Jamming II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 27
-				log "Merchant Levels" "Level 27" "Chose jamming upgrade."
+				log Levels "Merchant" "Level 27: Chose jamming upgrade."
 			`"Jamming? Wow, I never even thought about that before," Maribelle says. "It should alleviate some missile pressure, shouldn't it?"`
 				decline
 			label concealment
@@ -635,7 +635,7 @@ mission "Merchant's Guild Level 27"
 				outfit "Concealment II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 27
-				log "Merchant Levels" "Level 27" "Chose concealment upgrade."
+				log Levels "Merchant" "Level 27: Chose concealment upgrade."
 			`"Ooh, concealment? What are you trying to hide, Captain? An embarassing sixth-grade photo?" Maribelle jokes, giggling.`
 				decline
 
@@ -673,7 +673,7 @@ mission "Merchant's Guild Level 28"
 				outfit "Shields II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 28
-				log "Merchant Levels" "Level 28" "Chose shield upgrade."
+				log Levels "Merchant" "Level 28: Chose shield upgrade."
 			`Maribelle nods in agreement. "More shields can't hurt, can it?" She asks.`
 				goto next
 			label hullcap
@@ -681,7 +681,7 @@ mission "Merchant's Guild Level 28"
 				outfit "Hull II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 28
-				log "Merchant Levels" "Level 28" "Chose hull upgrade."
+				log Levels "Merchant" "Level 28: Chose hull upgrade."
 			`Maribelle nods in agreement. "More hull can't hurt, can it?" She asks.`
 				goto next
 			label cargocap
@@ -689,7 +689,7 @@ mission "Merchant's Guild Level 28"
 				outfit "Cargo II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 28
-				log "Merchant Levels" "Level 28" "Chose cargo upgrade."
+				log Levels "Merchant" "Level 28: Chose cargo upgrade."
 			`"Well, she is rewarding it for merchant work. It does make sense we'd want to do more, faster," Maribelle says.`
 				goto next
 			label fuelcap
@@ -697,7 +697,7 @@ mission "Merchant's Guild Level 28"
 				outfit "Fuel II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 28
-				log "Merchant Levels" "Level 28" "Chose fuel upgrade."
+				log Levels "Merchant" "Level 28: Chose fuel upgrade."
 			`"I didn't even know I could get my fuel capacity increased separately," Maribelle admits.`
 				goto next
 			label jamming
@@ -705,7 +705,7 @@ mission "Merchant's Guild Level 28"
 				outfit "Jamming II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 28
-				log "Merchant Levels" "Level 28" "Chose jamming upgrade."
+				log Levels "Merchant" "Level 28: Chose jamming upgrade."
 			`"Jamming? Wow, I never even thought about that before," Maribelle says. "It should alleviate some missile pressure, shouldn't it?"`
 				goto next
 			label concealment
@@ -713,7 +713,7 @@ mission "Merchant's Guild Level 28"
 				outfit "Concealment II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 28
-				log "Merchant Levels" "Level 28" "Chose concealment upgrade."
+				log Levels "Merchant" "Level 28: Chose concealment upgrade."
 			`"Ooh, concealment? What are you trying to hide, Captain? An embarassing sixth-grade photo?" Maribelle jokes, giggling.`
 				goto next
 
@@ -757,7 +757,7 @@ mission "Merchant's Guild Level 29"
 				outfit "Shields II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 29
-				log "Merchant Levels" "Level 29" "Chose shield upgrade."
+				log Levels "Merchant" "Level 29: Chose shield upgrade."
 			`Maribelle nods in agreement. "More shields can't hurt, can it?" She asks.`
 				decline
 			label hullcap
@@ -765,7 +765,7 @@ mission "Merchant's Guild Level 29"
 				outfit "Hull II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 29
-				log "Merchant Levels" "Level 29" "Chose hull upgrade."
+				log Levels "Merchant" "Level 29: Chose hull upgrade."
 			`Maribelle nods in agreement. "More hull can't hurt, can it?" She asks.`
 				decline
 			label cargocap
@@ -773,7 +773,7 @@ mission "Merchant's Guild Level 29"
 				outfit "Cargo II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 29
-				log "Merchant Levels" "Level 29" "Chose cargo upgrade."
+				log Levels "Merchant" "Level 29: Chose cargo upgrade."
 			`"Well, she is rewarding it for merchant work. It does make sense we'd want to do more, faster," Maribelle says.`
 				decline
 			label fuelcap
@@ -781,7 +781,7 @@ mission "Merchant's Guild Level 29"
 				outfit "Fuel II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 29
-				log "Merchant Levels" "Level 29" "Chose fuel upgrade."
+				log Levels "Merchant" "Level 29: Chose fuel upgrade."
 			`"I didn't even know I could get my fuel capacity increased separately," Maribelle admits.`
 				decline
 			label jamming
@@ -789,7 +789,7 @@ mission "Merchant's Guild Level 29"
 				outfit "Jamming II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 29
-				log "Merchant Levels" "Level 29" "Chose jamming upgrade."
+				log Levels "Merchant" "Level 29: Chose jamming upgrade."
 			`"Jamming? Wow, I never even thought about that before," Maribelle says. "It should alleviate some missile pressure, shouldn't it?"`
 				decline
 			label concealment
@@ -797,7 +797,7 @@ mission "Merchant's Guild Level 29"
 				outfit "Concealment II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 29
-				log "Merchant Levels" "Level 29" "Chose concealment upgrade."
+				log Levels "Merchant" "Level 29: Chose concealment upgrade."
 			`"Ooh, concealment? What are you trying to hide, Captain? An embarassing sixth-grade photo?" Maribelle jokes, giggling.`
 				decline
 
@@ -835,7 +835,7 @@ mission "Merchant's Guild Level 30"
 				outfit "Shields II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 30
-				log "Merchant Levels" "Level 30" "Chose shield upgrade."
+				log Levels "Merchant" "Level 30: Chose shield upgrade."
 			`Maribelle nods in agreement. "More shields can't hurt, can it?" She asks.`
 				goto next
 			label hullcap
@@ -843,7 +843,7 @@ mission "Merchant's Guild Level 30"
 				outfit "Hull II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 30
-				log "Merchant Levels" "Level 30" "Chose hull upgrade."
+				log Levels "Merchant" "Level 30: Chose hull upgrade."
 			`Maribelle nods in agreement. "More hull can't hurt, can it?" She asks.`
 				goto next
 			label cargocap
@@ -851,7 +851,7 @@ mission "Merchant's Guild Level 30"
 				outfit "Cargo II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 30
-				log "Merchant Levels" "Level 30" "Chose cargo upgrade."
+				log Levels "Merchant" "Level 30: Chose cargo upgrade."
 			`"Well, she is rewarding it for merchant work. It does make sense we'd want to do more, faster," Maribelle says.`
 				goto next
 			label fuelcap
@@ -859,7 +859,7 @@ mission "Merchant's Guild Level 30"
 				outfit "Fuel II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 30
-				log "Merchant Levels" "Level 30" "Chose fuel upgrade."
+				log Levels "Merchant" "Level 30: Chose fuel upgrade."
 			`"I didn't even know I could get my fuel capacity increased separately," Maribelle admits.`
 				goto next
 			label jamming
@@ -867,7 +867,7 @@ mission "Merchant's Guild Level 30"
 				outfit "Jamming II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 30
-				log "Merchant Levels" "Level 30" "Chose jamming upgrade."
+				log Levels "Merchant" "Level 30: Chose jamming upgrade."
 			`"Jamming? Wow, I never even thought about that before," Maribelle says. "It should alleviate some missile pressure, shouldn't it?"`
 				goto next
 			label concealment
@@ -875,7 +875,7 @@ mission "Merchant's Guild Level 30"
 				outfit "Concealment II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 30
-				log "Merchant Levels" "Level 30" "Chose concealment upgrade."
+				log Levels "Merchant" "Level 30: Chose concealment upgrade."
 			`"Ooh, concealment? What are you trying to hide, Captain? An embarassing sixth-grade photo?" Maribelle jokes, giggling.`
 				goto next
 
@@ -919,7 +919,7 @@ mission "Merchant's Guild Level 31"
 				outfit "Shields II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 31
-				log "Merchant Levels" "Level 31" "Chose shield upgrade."
+				log Levels "Merchant" "Level 31: Chose shield upgrade."
 			`Maribelle nods in agreement. "More shields can't hurt, can it?" She asks.`
 				decline
 			label hullcap
@@ -927,7 +927,7 @@ mission "Merchant's Guild Level 31"
 				outfit "Hull II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 31
-				log "Merchant Levels" "Level 31" "Chose hull upgrade."
+				log Levels "Merchant" "Level 31: Chose hull upgrade."
 			`Maribelle nods in agreement. "More hull can't hurt, can it?" She asks.`
 				decline
 			label cargocap
@@ -935,7 +935,7 @@ mission "Merchant's Guild Level 31"
 				outfit "Cargo II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 31
-				log "Merchant Levels" "Level 31" "Chose cargo upgrade."
+				log Levels "Merchant" "Level 31: Chose cargo upgrade."
 			`"Well, she is rewarding it for merchant work. It does make sense we'd want to do more, faster," Maribelle says.`
 				decline
 			label fuelcap
@@ -943,7 +943,7 @@ mission "Merchant's Guild Level 31"
 				outfit "Fuel II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 31
-				log "Merchant Levels" "Level 31" "Chose fuel upgrade."
+				log Levels "Merchant" "Level 31: Chose fuel upgrade."
 			`"I didn't even know I could get my fuel capacity increased separately," Maribelle admits.`
 				decline
 			label jamming
@@ -951,7 +951,7 @@ mission "Merchant's Guild Level 31"
 				outfit "Jamming II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 31
-				log "Merchant Levels" "Level 31" "Chose jamming upgrade."
+				log Levels "Merchant" "Level 31: Chose jamming upgrade."
 			`"Jamming? Wow, I never even thought about that before," Maribelle says. "It should alleviate some missile pressure, shouldn't it?"`
 				decline
 			label concealment
@@ -959,7 +959,7 @@ mission "Merchant's Guild Level 31"
 				outfit "Concealment II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 31
-				log "Merchant Levels" "Level 31" "Chose concealment upgrade."
+				log Levels "Merchant" "Level 31: Chose concealment upgrade."
 			`"Ooh, concealment? What are you trying to hide, Captain? An embarassing sixth-grade photo?" Maribelle jokes, giggling.`
 				decline
 
@@ -997,7 +997,7 @@ mission "Merchant's Guild Level 32"
 				outfit "Shields II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 32
-				log "Merchant Levels" "Level 32" "Chose shield upgrade."
+				log Levels "Merchant" "Level 32: Chose shield upgrade."
 			`Maribelle nods in agreement. "More shields can't hurt, can it?" She asks.`
 				goto next
 			label hullcap
@@ -1005,7 +1005,7 @@ mission "Merchant's Guild Level 32"
 				outfit "Hull II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 32
-				log "Merchant Levels" "Level 32" "Chose hull upgrade."
+				log Levels "Merchant" "Level 32: Chose hull upgrade."
 			`Maribelle nods in agreement. "More hull can't hurt, can it?" She asks.`
 				goto next
 			label cargocap
@@ -1013,7 +1013,7 @@ mission "Merchant's Guild Level 32"
 				outfit "Cargo II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 32
-				log "Merchant Levels" "Level 32" "Chose cargo upgrade."
+				log Levels "Merchant" "Level 32: Chose cargo upgrade."
 			`"Well, she is rewarding it for merchant work. It does make sense we'd want to do more, faster," Maribelle says.`
 				goto next
 			label fuelcap
@@ -1021,7 +1021,7 @@ mission "Merchant's Guild Level 32"
 				outfit "Fuel II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 32
-				log "Merchant Levels" "Level 32" "Chose fuel upgrade."
+				log Levels "Merchant" "Level 32: Chose fuel upgrade."
 			`"I didn't even know I could get my fuel capacity increased separately," Maribelle admits.`
 				goto next
 			label jamming
@@ -1029,7 +1029,7 @@ mission "Merchant's Guild Level 32"
 				outfit "Jamming II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 32
-				log "Merchant Levels" "Level 32" "Chose jamming upgrade."
+				log Levels "Merchant" "Level 32: Chose jamming upgrade."
 			`"Jamming? Wow, I never even thought about that before," Maribelle says. "It should alleviate some missile pressure, shouldn't it?"`
 				goto next
 			label concealment
@@ -1037,7 +1037,7 @@ mission "Merchant's Guild Level 32"
 				outfit "Concealment II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 32
-				log "Merchant Levels" "Level 32" "Chose concealment upgrade."
+				log Levels "Merchant" "Level 32: Chose concealment upgrade."
 			`"Ooh, concealment? What are you trying to hide, Captain? An embarassing sixth-grade photo?" Maribelle jokes, giggling.`
 				goto next
 
@@ -1081,7 +1081,7 @@ mission "Merchant's Guild Level 33"
 				outfit "Shields II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 33
-				log "Merchant Levels" "Level 33" "Chose shield upgrade."
+				log Levels "Merchant" "Level 33: Chose shield upgrade."
 			`Maribelle nods in agreement. "More shields can't hurt, can it?" She asks.`
 				decline
 			label hullcap
@@ -1089,7 +1089,7 @@ mission "Merchant's Guild Level 33"
 				outfit "Hull II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 33
-				log "Merchant Levels" "Level 33" "Chose hull upgrade."
+				log Levels "Merchant" "Level 33: Chose hull upgrade."
 			`Maribelle nods in agreement. "More hull can't hurt, can it?" She asks.`
 				decline
 			label cargocap
@@ -1097,7 +1097,7 @@ mission "Merchant's Guild Level 33"
 				outfit "Cargo II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 33
-				log "Merchant Levels" "Level 33" "Chose cargo upgrade."
+				log Levels "Merchant" "Level 33: Chose cargo upgrade."
 			`"Well, she is rewarding it for merchant work. It does make sense we'd want to do more, faster," Maribelle says.`
 				decline
 			label fuelcap
@@ -1105,7 +1105,7 @@ mission "Merchant's Guild Level 33"
 				outfit "Fuel II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 33
-				log "Merchant Levels" "Level 33" "Chose fuel upgrade."
+				log Levels "Merchant" "Level 33: Chose fuel upgrade."
 			`"I didn't even know I could get my fuel capacity increased separately," Maribelle admits.`
 				decline
 			label jamming
@@ -1113,7 +1113,7 @@ mission "Merchant's Guild Level 33"
 				outfit "Jamming II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 33
-				log "Merchant Levels" "Level 33" "Chose jamming upgrade."
+				log Levels "Merchant" "Level 33: Chose jamming upgrade."
 			`"Jamming? Wow, I never even thought about that before," Maribelle says. "It should alleviate some missile pressure, shouldn't it?"`
 				decline
 			label concealment
@@ -1121,7 +1121,7 @@ mission "Merchant's Guild Level 33"
 				outfit "Concealment II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 33
-				log "Merchant Levels" "Level 33" "Chose concealment upgrade."
+				log Levels "Merchant" "Level 33: Chose concealment upgrade."
 			`"Ooh, concealment? What are you trying to hide, Captain? An embarassing sixth-grade photo?" Maribelle jokes, giggling.`
 				decline
 
@@ -1159,7 +1159,7 @@ mission "Merchant's Guild Level 34"
 				outfit "Shields II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 34
-				log "Merchant Levels" "Level 34" "Chose shield upgrade."
+				log Levels "Merchant" "Level 34: Chose shield upgrade."
 			`Maribelle nods in agreement. "More shields can't hurt, can it?" She asks.`
 				goto next
 			label hullcap
@@ -1167,7 +1167,7 @@ mission "Merchant's Guild Level 34"
 				outfit "Hull II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 34
-				log "Merchant Levels" "Level 34" "Chose hull upgrade."
+				log Levels "Merchant" "Level 34: Chose hull upgrade."
 			`Maribelle nods in agreement. "More hull can't hurt, can it?" She asks.`
 				goto next
 			label cargocap
@@ -1175,7 +1175,7 @@ mission "Merchant's Guild Level 34"
 				outfit "Cargo II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 34
-				log "Merchant Levels" "Level 34" "Chose cargo upgrade."
+				log Levels "Merchant" "Level 34: Chose cargo upgrade."
 			`"Well, she is rewarding it for merchant work. It does make sense we'd want to do more, faster," Maribelle says.`
 				goto next
 			label fuelcap
@@ -1183,7 +1183,7 @@ mission "Merchant's Guild Level 34"
 				outfit "Fuel II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 34
-				log "Merchant Levels" "Level 34" "Chose fuel upgrade."
+				log Levels "Merchant" "Level 34: Chose fuel upgrade."
 			`"I didn't even know I could get my fuel capacity increased separately," Maribelle admits.`
 				goto next
 			label jamming
@@ -1191,7 +1191,7 @@ mission "Merchant's Guild Level 34"
 				outfit "Jamming II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 34
-				log "Merchant Levels" "Level 34" "Chose jamming upgrade."
+				log Levels "Merchant" "Level 34: Chose jamming upgrade."
 			`"Jamming? Wow, I never even thought about that before," Maribelle says. "It should alleviate some missile pressure, shouldn't it?"`
 				goto next
 			label concealment
@@ -1199,7 +1199,7 @@ mission "Merchant's Guild Level 34"
 				outfit "Concealment II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 34
-				log "Merchant Levels" "Level 34" "Chose concealment upgrade."
+				log Levels "Merchant" "Level 34: Chose concealment upgrade."
 			`"Ooh, concealment? What are you trying to hide, Captain? An embarassing sixth-grade photo?" Maribelle jokes, giggling.`
 				goto next
 
@@ -1243,7 +1243,7 @@ mission "Merchant's Guild Level 35"
 				outfit "Shields II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 35
-				log "Merchant Levels" "Level 35" "Chose shield upgrade."
+				log Levels "Merchant" "Level 35: Chose shield upgrade."
 			`Maribelle nods in agreement. "More shields can't hurt, can it?" She asks.`
 				decline
 			label hullcap
@@ -1251,7 +1251,7 @@ mission "Merchant's Guild Level 35"
 				outfit "Hull II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 35
-				log "Merchant Levels" "Level 35" "Chose hull upgrade."
+				log Levels "Merchant" "Level 35: Chose hull upgrade."
 			`Maribelle nods in agreement. "More hull can't hurt, can it?" She asks.`
 				decline
 			label cargocap
@@ -1259,7 +1259,7 @@ mission "Merchant's Guild Level 35"
 				outfit "Cargo II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 35
-				log "Merchant Levels" "Level 35" "Chose cargo upgrade."
+				log Levels "Merchant" "Level 35: Chose cargo upgrade."
 			`"Well, she is rewarding it for merchant work. It does make sense we'd want to do more, faster," Maribelle says.`
 				decline
 			label fuelcap
@@ -1267,7 +1267,7 @@ mission "Merchant's Guild Level 35"
 				outfit "Fuel II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 35
-				log "Merchant Levels" "Level 35" "Chose fuel upgrade."
+				log Levels "Merchant" "Level 35: Chose fuel upgrade."
 			`"I didn't even know I could get my fuel capacity increased separately," Maribelle admits.`
 				decline
 			label jamming
@@ -1275,7 +1275,7 @@ mission "Merchant's Guild Level 35"
 				outfit "Jamming II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 35
-				log "Merchant Levels" "Level 35" "Chose jamming upgrade."
+				log Levels "Merchant" "Level 35: Chose jamming upgrade."
 			`"Jamming? Wow, I never even thought about that before," Maribelle says. "It should alleviate some missile pressure, shouldn't it?"`
 				decline
 			label concealment
@@ -1283,7 +1283,7 @@ mission "Merchant's Guild Level 35"
 				outfit "Concealment II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 35
-				log "Merchant Levels" "Level 35" "Chose concealment upgrade."
+				log Levels "Merchant" "Level 35: Chose concealment upgrade."
 			`"Ooh, concealment? What are you trying to hide, Captain? An embarassing sixth-grade photo?" Maribelle jokes, giggling.`
 				decline
 
@@ -1321,7 +1321,7 @@ mission "Merchant's Guild Level 36"
 				outfit "Shields II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 36
-				log "Merchant Levels" "Level 36" "Chose shield upgrade."
+				log Levels "Merchant" "Level 36: Chose shield upgrade."
 			`Maribelle nods in agreement. "More shields can't hurt, can it?" She asks.`
 				goto next
 			label hullcap
@@ -1329,7 +1329,7 @@ mission "Merchant's Guild Level 36"
 				outfit "Hull II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 36
-				log "Merchant Levels" "Level 36" "Chose hull upgrade."
+				log Levels "Merchant" "Level 36: Chose hull upgrade."
 			`Maribelle nods in agreement. "More hull can't hurt, can it?" She asks.`
 				goto next
 			label cargocap
@@ -1337,7 +1337,7 @@ mission "Merchant's Guild Level 36"
 				outfit "Cargo II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 36
-				log "Merchant Levels" "Level 36" "Chose cargo upgrade."
+				log Levels "Merchant" "Level 36: Chose cargo upgrade."
 			`"Well, she is rewarding it for merchant work. It does make sense we'd want to do more, faster," Maribelle says.`
 				goto next
 			label fuelcap
@@ -1345,7 +1345,7 @@ mission "Merchant's Guild Level 36"
 				outfit "Fuel II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 36
-				log "Merchant Levels" "Level 36" "Chose fuel upgrade."
+				log Levels "Merchant" "Level 36: Chose fuel upgrade."
 			`"I didn't even know I could get my fuel capacity increased separately," Maribelle admits.`
 				goto next
 			label jamming
@@ -1353,7 +1353,7 @@ mission "Merchant's Guild Level 36"
 				outfit "Jamming II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 36
-				log "Merchant Levels" "Level 36" "Chose jamming upgrade."
+				log Levels "Merchant" "Level 36: Chose jamming upgrade."
 			`"Jamming? Wow, I never even thought about that before," Maribelle says. "It should alleviate some missile pressure, shouldn't it?"`
 				goto next
 			label concealment
@@ -1361,7 +1361,7 @@ mission "Merchant's Guild Level 36"
 				outfit "Concealment II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 36
-				log "Merchant Levels" "Level 36" "Chose concealment upgrade."
+				log Levels "Merchant" "Level 36: Chose concealment upgrade."
 			`"Ooh, concealment? What are you trying to hide, Captain? An embarassing sixth-grade photo?" Maribelle jokes, giggling.`
 				goto next
 
@@ -1405,7 +1405,7 @@ mission "Merchant's Guild Level 37"
 				outfit "Shields II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 37
-				log "Merchant Levels" "Level 37" "Chose shield upgrade."
+				log Levels "Merchant" "Level 37: Chose shield upgrade."
 			`Maribelle nods in agreement. "More shields can't hurt, can it?" She asks.`
 				decline
 			label hullcap
@@ -1413,7 +1413,7 @@ mission "Merchant's Guild Level 37"
 				outfit "Hull II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 37
-				log "Merchant Levels" "Level 37" "Chose hull upgrade."
+				log Levels "Merchant" "Level 37: Chose hull upgrade."
 			`Maribelle nods in agreement. "More hull can't hurt, can it?" She asks.`
 				decline
 			label cargocap
@@ -1421,7 +1421,7 @@ mission "Merchant's Guild Level 37"
 				outfit "Cargo II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 37
-				log "Merchant Levels" "Level 37" "Chose cargo upgrade."
+				log Levels "Merchant" "Level 37: Chose cargo upgrade."
 			`"Well, she is rewarding it for merchant work. It does make sense we'd want to do more, faster," Maribelle says.`
 				decline
 			label fuelcap
@@ -1429,7 +1429,7 @@ mission "Merchant's Guild Level 37"
 				outfit "Fuel II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 37
-				log "Merchant Levels" "Level 37" "Chose fuel upgrade."
+				log Levels "Merchant" "Level 37: Chose fuel upgrade."
 			`"I didn't even know I could get my fuel capacity increased separately," Maribelle admits.`
 				decline
 			label jamming
@@ -1437,7 +1437,7 @@ mission "Merchant's Guild Level 37"
 				outfit "Jamming II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 37
-				log "Merchant Levels" "Level 37" "Chose jamming upgrade."
+				log Levels "Merchant" "Level 37: Chose jamming upgrade."
 			`"Jamming? Wow, I never even thought about that before," Maribelle says. "It should alleviate some missile pressure, shouldn't it?"`
 				decline
 			label concealment
@@ -1445,7 +1445,7 @@ mission "Merchant's Guild Level 37"
 				outfit "Concealment II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 37
-				log "Merchant Levels" "Level 37" "Chose concealment upgrade."
+				log Levels "Merchant" "Level 37: Chose concealment upgrade."
 			`"Ooh, concealment? What are you trying to hide, Captain? An embarassing sixth-grade photo?" Maribelle jokes, giggling.`
 				decline
 
@@ -1483,7 +1483,7 @@ mission "Merchant's Guild Level 38"
 				outfit "Shields II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 38
-				log "Merchant Levels" "Level 38" "Chose shield upgrade."
+				log Levels "Merchant" "Level 38: Chose shield upgrade."
 			`Maribelle nods in agreement. "More shields can't hurt, can it?" She asks.`
 				goto next
 			label hullcap
@@ -1491,7 +1491,7 @@ mission "Merchant's Guild Level 38"
 				outfit "Hull II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 38
-				log "Merchant Levels" "Level 38" "Chose hull upgrade."
+				log Levels "Merchant" "Level 38: Chose hull upgrade."
 			`Maribelle nods in agreement. "More hull can't hurt, can it?" She asks.`
 				goto next
 			label cargocap
@@ -1499,7 +1499,7 @@ mission "Merchant's Guild Level 38"
 				outfit "Cargo II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 38
-				log "Merchant Levels" "Level 38" "Chose cargo upgrade."
+				log Levels "Merchant" "Level 38: Chose cargo upgrade."
 			`"Well, she is rewarding it for merchant work. It does make sense we'd want to do more, faster," Maribelle says.`
 				goto next
 			label fuelcap
@@ -1507,7 +1507,7 @@ mission "Merchant's Guild Level 38"
 				outfit "Fuel II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 38
-				log "Merchant Levels" "Level 38" "Chose fuel upgrade."
+				log Levels "Merchant" "Level 38: Chose fuel upgrade."
 			`"I didn't even know I could get my fuel capacity increased separately," Maribelle admits.`
 				goto next
 			label jamming
@@ -1515,7 +1515,7 @@ mission "Merchant's Guild Level 38"
 				outfit "Jamming II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 38
-				log "Merchant Levels" "Level 38" "Chose jamming upgrade."
+				log Levels "Merchant" "Level 38: Chose jamming upgrade."
 			`"Jamming? Wow, I never even thought about that before," Maribelle says. "It should alleviate some missile pressure, shouldn't it?"`
 				goto next
 			label concealment
@@ -1523,7 +1523,7 @@ mission "Merchant's Guild Level 38"
 				outfit "Concealment II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 38
-				log "Merchant Levels" "Level 38" "Chose concealment upgrade."
+				log Levels "Merchant" "Level 38: Chose concealment upgrade."
 			`"Ooh, concealment? What are you trying to hide, Captain? An embarassing sixth-grade photo?" Maribelle jokes, giggling.`
 				goto next
 
@@ -1567,7 +1567,7 @@ mission "Merchant's Guild Level 39"
 				outfit "Shields II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 39
-				log "Merchant Levels" "Level 39" "Chose shield upgrade."
+				log Levels "Merchant" "Level 39: Chose shield upgrade."
 			`Maribelle nods in agreement. "More shields can't hurt, can it?" She asks.`
 				decline
 			label hullcap
@@ -1575,7 +1575,7 @@ mission "Merchant's Guild Level 39"
 				outfit "Hull II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 39
-				log "Merchant Levels" "Level 39" "Chose hull upgrade."
+				log Levels "Merchant" "Level 39: Chose hull upgrade."
 			`Maribelle nods in agreement. "More hull can't hurt, can it?" She asks.`
 				decline
 			label cargocap
@@ -1583,7 +1583,7 @@ mission "Merchant's Guild Level 39"
 				outfit "Cargo II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 39
-				log "Merchant Levels" "Level 39" "Chose cargo upgrade."
+				log Levels "Merchant" "Level 39: Chose cargo upgrade."
 			`"Well, she is rewarding it for merchant work. It does make sense we'd want to do more, faster," Maribelle says.`
 				decline
 			label fuelcap
@@ -1591,7 +1591,7 @@ mission "Merchant's Guild Level 39"
 				outfit "Fuel II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 39
-				log "Merchant Levels" "Level 39" "Chose fuel upgrade."
+				log Levels "Merchant" "Level 39: Chose fuel upgrade."
 			`"I didn't even know I could get my fuel capacity increased separately," Maribelle admits.`
 				decline
 			label jamming
@@ -1599,7 +1599,7 @@ mission "Merchant's Guild Level 39"
 				outfit "Jamming II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 39
-				log "Merchant Levels" "Level 39" "Chose jamming upgrade."
+				log Levels "Merchant" "Level 39: Chose jamming upgrade."
 			`"Jamming? Wow, I never even thought about that before," Maribelle says. "It should alleviate some missile pressure, shouldn't it?"`
 				decline
 			label concealment
@@ -1607,7 +1607,7 @@ mission "Merchant's Guild Level 39"
 				outfit "Concealment II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 39
-				log "Merchant Levels" "Level 39" "Chose concealment upgrade."
+				log Levels "Merchant" "Level 39: Chose concealment upgrade."
 			`"Ooh, concealment? What are you trying to hide, Captain? An embarassing sixth-grade photo?" Maribelle jokes, giggling.`
 				decline
 
@@ -1645,7 +1645,7 @@ mission "Merchant's Guild Level 40"
 				outfit "Shields II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 40
-				log "Merchant Levels" "Level 40" "Chose shield upgrade."
+				log Levels "Merchant" "Level 40: Chose shield upgrade."
 			`Maribelle nods in agreement. "More shields can't hurt, can it?" She asks.`
 				goto next
 			label hullcap
@@ -1653,7 +1653,7 @@ mission "Merchant's Guild Level 40"
 				outfit "Hull II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 40
-				log "Merchant Levels" "Level 40" "Chose hull upgrade."
+				log Levels "Merchant" "Level 40: Chose hull upgrade."
 			`Maribelle nods in agreement. "More hull can't hurt, can it?" She asks.`
 				goto next
 			label cargocap
@@ -1661,7 +1661,7 @@ mission "Merchant's Guild Level 40"
 				outfit "Cargo II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 40
-				log "Merchant Levels" "Level 40" "Chose cargo upgrade."
+				log Levels "Merchant" "Level 40: Chose cargo upgrade."
 			`"Well, she is rewarding it for merchant work. It does make sense we'd want to do more, faster," Maribelle says.`
 				goto next
 			label fuelcap
@@ -1669,7 +1669,7 @@ mission "Merchant's Guild Level 40"
 				outfit "Fuel II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 40
-				log "Merchant Levels" "Level 40" "Chose fuel upgrade."
+				log Levels "Merchant" "Level 40: Chose fuel upgrade."
 			`"I didn't even know I could get my fuel capacity increased separately," Maribelle admits.`
 				goto next
 			label jamming
@@ -1677,7 +1677,7 @@ mission "Merchant's Guild Level 40"
 				outfit "Jamming II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 40
-				log "Merchant Levels" "Level 40" "Chose jamming upgrade."
+				log Levels "Merchant" "Level 40: Chose jamming upgrade."
 			`"Jamming? Wow, I never even thought about that before," Maribelle says. "It should alleviate some missile pressure, shouldn't it?"`
 				goto next
 			label concealment
@@ -1685,7 +1685,7 @@ mission "Merchant's Guild Level 40"
 				outfit "Concealment II (Merchant)" 1
 				outfit "Basal Level II (Merchant)" 1
 				"merchant's guild level" = 40
-				log "Merchant Levels" "Level 40" "Chose concealment upgrade."
+				log Levels "Merchant" "Level 40: Chose concealment upgrade."
 			`"Ooh, concealment? What are you trying to hide, Captain? An embarassing sixth-grade photo?" Maribelle jokes, giggling.`
 				goto next
 

--- a/data/novaxys/acquisition.txt
+++ b/data/novaxys/acquisition.txt
@@ -280,7 +280,7 @@ mission "Novaxys Initialization"
 			action
 				"apoxys spec points" += 1
 				outfit "Fortitude" -1
-			`Fortitude increased by 1 (now &[outfit (flagship installed): Fortitude]).`
+			`Fortitude decreased by 1 (now &[outfit (flagship installed): Fortitude]).`
 				goto fortitude
 
 			label force
@@ -306,7 +306,7 @@ mission "Novaxys Initialization"
 			action
 				"apoxys spec points" += 1
 				outfit "Force" -1
-			`Force increased by 1 (now &[outfit (flagship installed): Force]).`
+			`Force decreased by 1 (now &[outfit (flagship installed): Force]).`
 				goto force
 
 			label focus
@@ -332,7 +332,7 @@ mission "Novaxys Initialization"
 			action
 				"apoxys spec points" += 1
 				outfit "Focus" -1
-			`Focus increased by 1 (now &[outfit (flagship installed): Focus]).`
+			`Focus decreased by 1 (now &[outfit (flagship installed): Focus]).`
 				goto focus
 
 			label flightiness
@@ -358,7 +358,7 @@ mission "Novaxys Initialization"
 			action
 				"apoxys spec points" += 1
 				outfit "Flightiness" -1
-			`Flightiness increased by 1 (now &[outfit (flagship installed): Flightiness]).`
+			`Flightiness decreased by 1 (now &[outfit (flagship installed): Flightiness]).`
 				goto flightiness
 
 			label friendliness
@@ -384,7 +384,7 @@ mission "Novaxys Initialization"
 			action
 				"apoxys spec points" += 1
 				outfit "Friendliness" -1
-			`Friendliness increased by 1 (now &[outfit (flagship installed): Friendliness]).`
+			`Friendliness decreased by 1 (now &[outfit (flagship installed): Friendliness]).`
 				goto friendliness
 
 			label finish

--- a/data/novaxys/level80.txt
+++ b/data/novaxys/level80.txt
@@ -368,6 +368,7 @@ mission "Novaxys Level 80 Choices"
 				"mark iv choices" == 0
 
 			label options
+			log Levels "Novaxys" "Levels 79-80: Re-chose upgrades."
 			`"I still have a lot of energy even after all that, Captain," Rosalynd expresses.`
 			`	"You still have special upgrades to do," You remind her.`
 			`	"Oh, right," Rosalynd nods.`

--- a/data/novaxys/levels1-40.txt
+++ b/data/novaxys/levels1-40.txt
@@ -174,6 +174,7 @@ mission "Novaxys Level 1-2"
 			`	You recall the times when Maribelle gets like this, explaining the concept of upgrades to Rosalynd. She seems to grasp it fairly quickly, though perhaps you shouldn't be quite so particular with your upgrade suggestions...`
 			action
 				"novaxys choices" = 2
+				"novaxys level" = 0
 			label pick
 			`You have &[novaxys choices] picks left.`
 			choice
@@ -191,25 +192,59 @@ mission "Novaxys Level 1-2"
 			label durability
 			action
 				outfit "Novaxys Durability I" 1
-				log "Novaxys Levels" "Levels 1-2" "Chose durability upgrade."
+			branch "first durability" "later durability"
+				"novaxys level" == 0
+			label "first durability"
+			action
+				"novaxys level" += 1
+				log Levels "Novaxys" "	Levels 1-2: Chose durability upgrade."
+			`"Okay, Captain," Rosalynd replies. "It would be nice to not get blown up."`
+				goto next
+			label "later durability"
+			action
+				log Levels "Novaxys" "Levels 1-2: Chose durability upgrade."
 			`"Okay, Captain," Rosalynd replies. "It would be nice to not get blown up."`
 				goto next
 			label support
 			action
 				outfit "Novaxys Support I" 1
-				log "Novaxys Levels" "Levels 1-2" "Chose support upgrade."
+			branch "first support" "later support"
+				"novaxys level" == 0
+			label "first support"
+				"novaxys level" += 1
+				log Levels "Novaxys" "	Levels 1-2: Chose support upgrade."
+			`"It doesn't hurt to carry extra equipment," Rosalynd agrees.`
+				goto next
+			label "later support"
+				log Levels "Novaxys" "Levels 1-2: Chose support upgrade."
 			`"It doesn't hurt to carry extra equipment," Rosalynd agrees.`
 				goto next
 			label combat
 			action
 				outfit "Novaxys Combat I" 1
-				log "Novaxys Levels" "Levels 1-2" "Chose combat upgrade."
+			branch "first combat" "later combat"
+				"novaxys level" == 0
+			label "first combat"
+				"novaxys level" += 1
+				log Levels "Novaxys" "	Levels 1-2: Chose combat upgrade."
+			`"I would like to be a stronger fighter," Rosalynd nods. "Okay, Captain."`
+				goto next
+			label "later combat"
+				log Levels "Novaxys" "Levels 1-2: Chose combat upgrade."
 			`"I would like to be a stronger fighter," Rosalynd nods. "Okay, Captain."`
 				goto next
 			label utility
 			action
 				outfit "Novaxys Utility I" 1
-				log "Novaxys Levels" "Levels 1-2" "Chose utility upgrade."
+			branch "first utility" "later utility"
+				"novaxys level" == 0
+			label "first utility"
+				"novaxys level" += 1
+				log Levels "Novaxys" "	Levels 1-2: Chose utility upgrade."
+			`"Utilities... I think I have a few ideas, Captain," Rosalynd nods.`
+				goto next
+			label "later utility"
+				log Levels "Novaxys" "Levels 1-2: Chose utility upgrade."
 			`"Utilities... I think I have a few ideas, Captain," Rosalynd nods.`
 				goto next
 
@@ -255,25 +290,25 @@ mission "Novaxys Level 3-4"
 			label durability
 			action
 				outfit "Novaxys Durability I" 1
-				log "Novaxys Levels" "Levels 3-4" "Chose durability upgrade."
+				log Levels "Novaxys" "Levels 3-4: Chose durability upgrade."
 			`"Okay, Captain," Rosalynd replies. "It would be nice to not get blown up."`
 				goto next
 			label support
 			action
 				outfit "Novaxys Support I" 1
-				log "Novaxys Levels" "Levels 3-4" "Chose support upgrade."
+				log Levels "Novaxys" "Levels 3-4: Chose support upgrade."
 			`"It doesn't hurt to carry extra equipment," Rosalynd agrees.`
 				goto next
 			label combat
 			action
 				outfit "Novaxys Combat I" 1
-				log "Novaxys Levels" "Levels 3-4" "Chose combat upgrade."
+				log Levels "Novaxys" "Levels 3-4: Chose combat upgrade."
 			`"I would like to be a stronger fighter," Rosalynd nods. "Okay, Captain."`
 				goto next
 			label utility
 			action
 				outfit "Novaxys Utility I" 1
-				log "Novaxys Levels" "Levels 3-4" "Chose utility upgrade."
+				log Levels "Novaxys" "Levels 3-4: Chose utility upgrade."
 			`"Utilities... I think I have a few ideas, Captain," Rosalynd nods.`
 				goto next
 
@@ -319,25 +354,25 @@ mission "Novaxys Level 5-6"
 			label durability
 			action
 				outfit "Novaxys Durability I" 1
-				log "Novaxys Levels" "Levels 5-6" "Chose durability upgrade."
+				log Levels "Novaxys" "Levels 5-6: Chose durability upgrade."
 			`"Okay, Captain," Rosalynd replies. "It would be nice to not get blown up."`
 				goto next
 			label support
 			action
 				outfit "Novaxys Support I" 1
-				log "Novaxys Levels" "Levels 5-6" "Chose support upgrade."
+				log Levels "Novaxys" "Levels 5-6: Chose support upgrade."
 			`"It doesn't hurt to carry extra equipment," Rosalynd agrees.`
 				goto next
 			label combat
 			action
 				outfit "Novaxys Combat I" 1
-				log "Novaxys Levels" "Levels 5-6" "Chose combat upgrade."
+				log Levels "Novaxys" "Levels 5-6: Chose combat upgrade."
 			`"I would like to be a stronger fighter," Rosalynd nods. "Okay, Captain."`
 				goto next
 			label utility
 			action
 				outfit "Novaxys Utility I" 1
-				log "Novaxys Levels" "Levels 5-6" "Chose utility upgrade."
+				log Levels "Novaxys" "Levels 5-6: Chose utility upgrade."
 			`"Utilities... I think I have a few ideas, Captain," Rosalynd nods.`
 				goto next
 
@@ -383,25 +418,25 @@ mission "Novaxys Level 7-8"
 			label durability
 			action
 				outfit "Novaxys Durability I" 1
-				log "Novaxys Levels" "Levels 7-8" "Chose durability upgrade."
+				log Levels "Novaxys" "Levels 7-8: Chose durability upgrade."
 			`"Okay, Captain," Rosalynd replies. "It would be nice to not get blown up."`
 				goto next
 			label support
 			action
 				outfit "Novaxys Support I" 1
-				log "Novaxys Levels" "Levels 7-8" "Chose support upgrade."
+				log Levels "Novaxys" "Levels 7-8: Chose support upgrade."
 			`"It doesn't hurt to carry extra equipment," Rosalynd agrees.`
 				goto next
 			label combat
 			action
 				outfit "Novaxys Combat I" 1
-				log "Novaxys Levels" "Levels 7-8" "Chose combat upgrade."
+				log Levels "Novaxys" "Levels 7-8: Chose combat upgrade."
 			`"I would like to be a stronger fighter," Rosalynd nods. "Okay, Captain."`
 				goto next
 			label utility
 			action
 				outfit "Novaxys Utility I" 1
-				log "Novaxys Levels" "Levels 7-8" "Chose utility upgrade."
+				log Levels "Novaxys" "Levels 7-8: Chose utility upgrade."
 			`"Utilities... I think I have a few ideas, Captain," Rosalynd nods.`
 				goto next
 
@@ -447,25 +482,25 @@ mission "Novaxys Level 9-10"
 			label durability
 			action
 				outfit "Novaxys Durability I" 1
-				log "Novaxys Levels" "Levels 9-10" "Chose durability upgrade."
+				log Levels "Novaxys" "Levels 9-10: Chose durability upgrade."
 			`"Okay, Captain," Rosalynd replies. "It would be nice to not get blown up."`
 				goto next
 			label support
 			action
 				outfit "Novaxys Support I" 1
-				log "Novaxys Levels" "Levels 9-10" "Chose support upgrade."
+				log Levels "Novaxys" "Levels 9-10: Chose support upgrade."
 			`"It doesn't hurt to carry extra equipment," Rosalynd agrees.`
 				goto next
 			label combat
 			action
 				outfit "Novaxys Combat I" 1
-				log "Novaxys Levels" "Levels 9-10" "Chose combat upgrade."
+				log Levels "Novaxys" "Levels 9-10: Chose combat upgrade."
 			`"I would like to be a stronger fighter," Rosalynd nods. "Okay, Captain."`
 				goto next
 			label utility
 			action
 				outfit "Novaxys Utility I" 1
-				log "Novaxys Levels" "Levels 9-10" "Chose utility upgrade."
+				log Levels "Novaxys" "Levels 9-10: Chose utility upgrade."
 			`"Utilities... I think I have a few ideas, Captain," Rosalynd nods.`
 				goto next
 
@@ -511,25 +546,25 @@ mission "Novaxys Level 11-12"
 			label durability
 			action
 				outfit "Novaxys Durability I" 1
-				log "Novaxys Levels" "Levels 11-12" "Chose durability upgrade."
+				log Levels "Novaxys" "Levels 11-12: Chose durability upgrade."
 			`"Okay, Captain," Rosalynd replies. "It would be nice to not get blown up."`
 				goto next
 			label support
 			action
 				outfit "Novaxys Support I" 1
-				log "Novaxys Levels" "Levels 11-12" "Chose support upgrade."
+				log Levels "Novaxys" "Levels 11-12: Chose support upgrade."
 			`"It doesn't hurt to carry extra equipment," Rosalynd agrees.`
 				goto next
 			label combat
 			action
 				outfit "Novaxys Combat I" 1
-				log "Novaxys Levels" "Levels 12-13" "Chose combat upgrade."
+				log Levels "Novaxys" "Levels 11-12: Chose combat upgrade."
 			`"I would like to be a stronger fighter," Rosalynd nods. "Okay, Captain."`
 				goto next
 			label utility
 			action
 				outfit "Novaxys Utility I" 1
-				log "Novaxys Levels" "Levels 12-13" "Chose utility upgrade."
+				log Levels "Novaxys" "Levels 11-12: Chose utility upgrade."
 			`"Utilities... I think I have a few ideas, Captain," Rosalynd nods.`
 				goto next
 
@@ -575,25 +610,25 @@ mission "Novaxys Level 13-14"
 			label durability
 			action
 				outfit "Novaxys Durability I" 1
-				log "Novaxys Levels" "Levels 13-14" "Chose durability upgrade."
+				log Levels "Novaxys" "Levels 13-14: Chose durability upgrade."
 			`"Okay, Captain," Rosalynd replies. "It would be nice to not get blown up."`
 				goto next
 			label support
 			action
 				outfit "Novaxys Support I" 1
-				log "Novaxys Levels" "Levels 13-14" "Chose support upgrade."
+				log Levels "Novaxys" "Levels 13-14: Chose support upgrade."
 			`"It doesn't hurt to carry extra equipment," Rosalynd agrees.`
 				goto next
 			label combat
 			action
 				outfit "Novaxys Combat I" 1
-				log "Novaxys Levels" "Levels 13-14" "Chose combat upgrade."
+				log Levels "Novaxys" "Levels 13-14: Chose combat upgrade."
 			`"I would like to be a stronger fighter," Rosalynd nods. "Okay, Captain."`
 				goto next
 			label utility
 			action
 				outfit "Novaxys Utility I" 1
-				log "Novaxys Levels" "Levels 13-14" "Chose utility upgrade."
+				log Levels "Novaxys" "Levels 13-14: Chose utility upgrade."
 			`"Utilities... I think I have a few ideas, Captain," Rosalynd nods.`
 				goto next
 
@@ -639,25 +674,25 @@ mission "Novaxys Level 15-16"
 			label durability
 			action
 				outfit "Novaxys Durability I" 1
-				log "Novaxys Levels" "Levels 15-16" "Chose durability upgrade."
+				log Levels "Novaxys" "Levels 15-16: Chose durability upgrade."
 			`"Okay, Captain," Rosalynd replies. "It would be nice to not get blown up."`
 				goto next
 			label support
 			action
 				outfit "Novaxys Support I" 1
-				log "Novaxys Levels" "Levels 15-16" "Chose support upgrade."
+				log Levels "Novaxys" "Levels 15-16: Chose support upgrade."
 			`"It doesn't hurt to carry extra equipment," Rosalynd agrees.`
 				goto next
 			label combat
 			action
 				outfit "Novaxys Combat I" 1
-				log "Novaxys Levels" "Levels 15-16" "Chose combat upgrade."
+				log Levels "Novaxys" "Levels 15-16: Chose combat upgrade."
 			`"I would like to be a stronger fighter," Rosalynd nods. "Okay, Captain."`
 				goto next
 			label utility
 			action
 				outfit "Novaxys Utility I" 1
-				log "Novaxys Levels" "Levels 15-16" "Chose utility upgrade."
+				log Levels "Novaxys" "Levels 15-16: Chose utility upgrade."
 			`"Utilities... I think I have a few ideas, Captain," Rosalynd nods.`
 				goto next
 
@@ -703,25 +738,25 @@ mission "Novaxys Level 17-18"
 			label durability
 			action
 				outfit "Novaxys Durability I" 1
-				log "Novaxys Levels" "Levels 17-18" "Chose durability upgrade."
+				log Levels "Novaxys" "Levels 17-18: Chose durability upgrade."
 			`"Okay, Captain," Rosalynd replies. "It would be nice to not get blown up."`
 				goto next
 			label support
 			action
 				outfit "Novaxys Support I" 1
-				log "Novaxys Levels" "Levels 17-18" "Chose support upgrade."
+				log Levels "Novaxys" "Levels 17-18: Chose support upgrade."
 			`"It doesn't hurt to carry extra equipment," Rosalynd agrees.`
 				goto next
 			label combat
 			action
 				outfit "Novaxys Combat I" 1
-				log "Novaxys Levels" "Levels 17-18" "Chose combat upgrade."
+				log Levels "Novaxys" "Levels 17-18: Chose combat upgrade."
 			`"I would like to be a stronger fighter," Rosalynd nods. "Okay, Captain."`
 				goto next
 			label utility
 			action
 				outfit "Novaxys Utility I" 1
-				log "Novaxys Levels" "Levels 17-18" "Chose utility upgrade."
+				log Levels "Novaxys" "Levels 17-18: Chose utility upgrade."
 			`"Utilities... I think I have a few ideas, Captain," Rosalynd nods.`
 				goto next
 
@@ -767,25 +802,25 @@ mission "Novaxys Level 19-20"
 			label durability
 			action
 				outfit "Novaxys Durability I" 1
-				log "Novaxys Levels" "Levels 19-20" "Chose durability upgrade."
+				log Levels "Novaxys" "Levels 19-20: Chose durability upgrade."
 			`"Okay, Captain," Rosalynd replies. "It would be nice to not get blown up."`
 				goto next
 			label support
 			action
 				outfit "Novaxys Support I" 1
-				log "Novaxys Levels" "Levels 19-20" "Chose support upgrade."
+				log Levels "Novaxys" "Levels 19-20: Chose support upgrade."
 			`"It doesn't hurt to carry extra equipment," Rosalynd agrees.`
 				goto next
 			label combat
 			action
 				outfit "Novaxys Combat I" 1
-				log "Novaxys Levels" "Levels 19-20" "Chose combat upgrade."
+				log Levels "Novaxys" "Levels 19-20: Chose combat upgrade."
 			`"I would like to be a stronger fighter," Rosalynd nods. "Okay, Captain."`
 				goto next
 			label utility
 			action
 				outfit "Novaxys Utility I" 1
-				log "Novaxys Levels" "Levels 19-20" "Chose utility upgrade."
+				log Levels "Novaxys" "Levels 19-20: Chose utility upgrade."
 			`"Utilities... I think I have a few ideas, Captain," Rosalynd nods.`
 				goto next
 
@@ -831,25 +866,25 @@ mission "Novaxys Level 21-22"
 			label durability
 			action
 				outfit "Novaxys Durability II" 1
-				log "Novaxys Levels" "Levels 21-22" "Chose durability upgrade."
+				log Levels "Novaxys" "Levels 21-22: Chose durability upgrade."
 			`"Okay, Captain," Rosalynd replies. "It would be nice to not get blown up."`
 				goto next
 			label support
 			action
 				outfit "Novaxys Support II" 1
-				log "Novaxys Levels" "Levels 21-22" "Chose support upgrade."
+				log Levels "Novaxys" "Levels 21-22: Chose support upgrade."
 			`"It doesn't hurt to carry extra equipment," Rosalynd agrees.`
 				goto next
 			label combat
 			action
 				outfit "Novaxys Combat II" 1
-				log "Novaxys Levels" "Levels 22-23" "Chose combat upgrade."
+				log Levels "Novaxys" "Levels 21-22: Chose combat upgrade."
 			`"I would like to be a stronger fighter," Rosalynd nods. "Okay, Captain."`
 				goto next
 			label utility
 			action
 				outfit "Novaxys Utility II" 1
-				log "Novaxys Levels" "Levels 22-23" "Chose utility upgrade."
+				log Levels "Novaxys" "Levels 21-22: Chose utility upgrade."
 			`"Utilities... I think I have a few ideas, Captain," Rosalynd nods.`
 				goto next
 
@@ -895,25 +930,25 @@ mission "Novaxys Level 23-24"
 			label durability
 			action
 				outfit "Novaxys Durability II" 1
-				log "Novaxys Levels" "Levels 23-24" "Chose durability upgrade."
+				log Levels "Novaxys" "Levels 23-24: Chose durability upgrade."
 			`"Okay, Captain," Rosalynd replies. "It would be nice to not get blown up."`
 				goto next
 			label support
 			action
 				outfit "Novaxys Support II" 1
-				log "Novaxys Levels" "Levels 23-24" "Chose support upgrade."
+				log Levels "Novaxys" "Levels 23-24: Chose support upgrade."
 			`"It doesn't hurt to carry extra equipment," Rosalynd agrees.`
 				goto next
 			label combat
 			action
 				outfit "Novaxys Combat II" 1
-				log "Novaxys Levels" "Levels 23-24" "Chose combat upgrade."
+				log Levels "Novaxys" "Levels 23-24: Chose combat upgrade."
 			`"I would like to be a stronger fighter," Rosalynd nods. "Okay, Captain."`
 				goto next
 			label utility
 			action
 				outfit "Novaxys Utility II" 1
-				log "Novaxys Levels" "Levels 23-24" "Chose utility upgrade."
+				log Levels "Novaxys" "Levels 23-24: Chose utility upgrade."
 			`"Utilities... I think I have a few ideas, Captain," Rosalynd nods.`
 				goto next
 
@@ -959,25 +994,25 @@ mission "Novaxys Level 25-26"
 			label durability
 			action
 				outfit "Novaxys Durability II" 1
-				log "Novaxys Levels" "Levels 25-26" "Chose durability upgrade."
+				log Levels "Novaxys" "Levels 25-26: Chose durability upgrade."
 			`"Okay, Captain," Rosalynd replies. "It would be nice to not get blown up."`
 				goto next
 			label support
 			action
 				outfit "Novaxys Support II" 1
-				log "Novaxys Levels" "Levels 25-26" "Chose support upgrade."
+				log Levels "Novaxys" "Levels 25-26: Chose support upgrade."
 			`"It doesn't hurt to carry extra equipment," Rosalynd agrees.`
 				goto next
 			label combat
 			action
 				outfit "Novaxys Combat II" 1
-				log "Novaxys Levels" "Levels 25-26" "Chose combat upgrade."
+				log Levels "Novaxys" "Levels 25-26: Chose combat upgrade."
 			`"I would like to be a stronger fighter," Rosalynd nods. "Okay, Captain."`
 				goto next
 			label utility
 			action
 				outfit "Novaxys Utility II" 1
-				log "Novaxys Levels" "Levels 25-26" "Chose utility upgrade."
+				log Levels "Novaxys" "Levels 25-26: Chose utility upgrade."
 			`"Utilities... I think I have a few ideas, Captain," Rosalynd nods.`
 				goto next
 
@@ -1023,25 +1058,25 @@ mission "Novaxys Level 27-28"
 			label durability
 			action
 				outfit "Novaxys Durability II" 1
-				log "Novaxys Levels" "Levels 27-28" "Chose durability upgrade."
+				log Levels "Novaxys" "Levels 27-28: Chose durability upgrade."
 			`"Okay, Captain," Rosalynd replies. "It would be nice to not get blown up."`
 				goto next
 			label support
 			action
 				outfit "Novaxys Support II" 1
-				log "Novaxys Levels" "Levels 27-28" "Chose support upgrade."
+				log Levels "Novaxys" "Levels 27-28: Chose support upgrade."
 			`"It doesn't hurt to carry extra equipment," Rosalynd agrees.`
 				goto next
 			label combat
 			action
 				outfit "Novaxys Combat II" 1
-				log "Novaxys Levels" "Levels 27-28" "Chose combat upgrade."
+				log Levels "Novaxys" "Levels 27-28: Chose combat upgrade."
 			`"I would like to be a stronger fighter," Rosalynd nods. "Okay, Captain."`
 				goto next
 			label utility
 			action
 				outfit "Novaxys Utility II" 1
-				log "Novaxys Levels" "Levels 27-28" "Chose utility upgrade."
+				log Levels "Novaxys" "Levels 27-28: Chose utility upgrade."
 			`"Utilities... I think I have a few ideas, Captain," Rosalynd nods.`
 				goto next
 
@@ -1087,25 +1122,25 @@ mission "Novaxys Level 29-30"
 			label durability
 			action
 				outfit "Novaxys Durability II" 1
-				log "Novaxys Levels" "Levels 29-30" "Chose durability upgrade."
+				log Levels "Novaxys" "Levels 29-30: Chose durability upgrade."
 			`"Okay, Captain," Rosalynd replies. "It would be nice to not get blown up."`
 				goto next
 			label support
 			action
 				outfit "Novaxys Support II" 1
-				log "Novaxys Levels" "Levels 29-30" "Chose support upgrade."
+				log Levels "Novaxys" "Levels 29-30: Chose support upgrade."
 			`"It doesn't hurt to carry extra equipment," Rosalynd agrees.`
 				goto next
 			label combat
 			action
 				outfit "Novaxys Combat II" 1
-				log "Novaxys Levels" "Levels 29-30" "Chose combat upgrade."
+				log Levels "Novaxys" "Levels 29-30: Chose combat upgrade."
 			`"I would like to be a stronger fighter," Rosalynd nods. "Okay, Captain."`
 				goto next
 			label utility
 			action
 				outfit "Novaxys Utility II" 1
-				log "Novaxys Levels" "Levels 29-30" "Chose utility upgrade."
+				log Levels "Novaxys" "Levels 29-30: Chose utility upgrade."
 			`"Utilities... I think I have a few ideas, Captain," Rosalynd nods.`
 				goto next
 
@@ -1151,25 +1186,25 @@ mission "Novaxys Level 31-32"
 			label durability
 			action
 				outfit "Novaxys Durability II" 1
-				log "Novaxys Levels" "Levels 31-32" "Chose durability upgrade."
+				log Levels "Novaxys" "Levels 31-32: Chose durability upgrade."
 			`"Okay, Captain," Rosalynd replies. "It would be nice to not get blown up."`
 				goto next
 			label support
 			action
 				outfit "Novaxys Support II" 1
-				log "Novaxys Levels" "Levels 31-32" "Chose support upgrade."
+				log Levels "Novaxys" "Levels 31-32: Chose support upgrade."
 			`"It doesn't hurt to carry extra equipment," Rosalynd agrees.`
 				goto next
 			label combat
 			action
 				outfit "Novaxys Combat II" 1
-				log "Novaxys Levels" "Levels 32-33" "Chose combat upgrade."
+				log Levels "Novaxys" "Levels 31-32: Chose combat upgrade."
 			`"I would like to be a stronger fighter," Rosalynd nods. "Okay, Captain."`
 				goto next
 			label utility
 			action
 				outfit "Novaxys Utility II" 1
-				log "Novaxys Levels" "Levels 32-33" "Chose utility upgrade."
+				log Levels "Novaxys" "Levels 31-32: Chose utility upgrade."
 			`"Utilities... I think I have a few ideas, Captain," Rosalynd nods.`
 				goto next
 
@@ -1215,25 +1250,25 @@ mission "Novaxys Level 33-34"
 			label durability
 			action
 				outfit "Novaxys Durability II" 1
-				log "Novaxys Levels" "Levels 33-34" "Chose durability upgrade."
+				log Levels "Novaxys" "Levels 33-34: Chose durability upgrade."
 			`"Okay, Captain," Rosalynd replies. "It would be nice to not get blown up."`
 				goto next
 			label support
 			action
 				outfit "Novaxys Support II" 1
-				log "Novaxys Levels" "Levels 33-34" "Chose support upgrade."
+				log Levels "Novaxys" "Levels 33-34: Chose support upgrade."
 			`"It doesn't hurt to carry extra equipment," Rosalynd agrees.`
 				goto next
 			label combat
 			action
 				outfit "Novaxys Combat II" 1
-				log "Novaxys Levels" "Levels 33-34" "Chose combat upgrade."
+				log Levels "Novaxys" "Levels 33-34: Chose combat upgrade."
 			`"I would like to be a stronger fighter," Rosalynd nods. "Okay, Captain."`
 				goto next
 			label utility
 			action
 				outfit "Novaxys Utility II" 1
-				log "Novaxys Levels" "Levels 33-34" "Chose utility upgrade."
+				log Levels "Novaxys" "Levels 33-34: Chose utility upgrade."
 			`"Utilities... I think I have a few ideas, Captain," Rosalynd nods.`
 				goto next
 
@@ -1279,25 +1314,25 @@ mission "Novaxys Level 35-36"
 			label durability
 			action
 				outfit "Novaxys Durability II" 1
-				log "Novaxys Levels" "Levels 35-36" "Chose durability upgrade."
+				log Levels "Novaxys" "Levels 35-36: Chose durability upgrade."
 			`"Okay, Captain," Rosalynd replies. "It would be nice to not get blown up."`
 				goto next
 			label support
 			action
 				outfit "Novaxys Support II" 1
-				log "Novaxys Levels" "Levels 35-36" "Chose support upgrade."
+				log Levels "Novaxys" "Levels 35-36: Chose support upgrade."
 			`"It doesn't hurt to carry extra equipment," Rosalynd agrees.`
 				goto next
 			label combat
 			action
 				outfit "Novaxys Combat II" 1
-				log "Novaxys Levels" "Levels 35-36" "Chose combat upgrade."
+				log Levels "Novaxys" "Levels 35-36: Chose combat upgrade."
 			`"I would like to be a stronger fighter," Rosalynd nods. "Okay, Captain."`
 				goto next
 			label utility
 			action
 				outfit "Novaxys Utility II" 1
-				log "Novaxys Levels" "Levels 35-36" "Chose utility upgrade."
+				log Levels "Novaxys" "Levels 35-36: Chose utility upgrade."
 			`"Utilities... I think I have a few ideas, Captain," Rosalynd nods.`
 				goto next
 
@@ -1343,25 +1378,25 @@ mission "Novaxys Level 37-38"
 			label durability
 			action
 				outfit "Novaxys Durability II" 1
-				log "Novaxys Levels" "Levels 37-38" "Chose durability upgrade."
+				log Levels "Novaxys" "Levels 37-38: Chose durability upgrade."
 			`"Okay, Captain," Rosalynd replies. "It would be nice to not get blown up."`
 				goto next
 			label support
 			action
 				outfit "Novaxys Support II" 1
-				log "Novaxys Levels" "Levels 37-38" "Chose support upgrade."
+				log Levels "Novaxys" "Levels 37-38: Chose support upgrade."
 			`"It doesn't hurt to carry extra equipment," Rosalynd agrees.`
 				goto next
 			label combat
 			action
 				outfit "Novaxys Combat II" 1
-				log "Novaxys Levels" "Levels 37-38" "Chose combat upgrade."
+				log Levels "Novaxys" "Levels 37-38: Chose combat upgrade."
 			`"I would like to be a stronger fighter," Rosalynd nods. "Okay, Captain."`
 				goto next
 			label utility
 			action
 				outfit "Novaxys Utility II" 1
-				log "Novaxys Levels" "Levels 37-38" "Chose utility upgrade."
+				log Levels "Novaxys" "Levels 37-38: Chose utility upgrade."
 			`"Utilities... I think I have a few ideas, Captain," Rosalynd nods.`
 				goto next
 
@@ -1407,25 +1442,25 @@ mission "Novaxys Level 39-40"
 			label durability
 			action
 				outfit "Novaxys Durability II" 1
-				log "Novaxys Levels" "Levels 39-40" "Chose durability upgrade."
+				log Levels "Novaxys" "Levels 39-40: Chose durability upgrade."
 			`"Okay, Captain," Rosalynd replies. "It would be nice to not get blown up."`
 				goto next
 			label support
 			action
 				outfit "Novaxys Support II" 1
-				log "Novaxys Levels" "Levels 39-40" "Chose support upgrade."
+				log Levels "Novaxys" "Levels 39-40: Chose support upgrade."
 			`"It doesn't hurt to carry extra equipment," Rosalynd agrees.`
 				goto next
 			label combat
 			action
 				outfit "Novaxys Combat II" 1
-				log "Novaxys Levels" "Levels 39-40" "Chose combat upgrade."
+				log Levels "Novaxys" "Levels 39-40: Chose combat upgrade."
 			`"I would like to be a stronger fighter," Rosalynd nods. "Okay, Captain."`
 				goto next
 			label utility
 			action
 				outfit "Novaxys Utility II" 1
-				log "Novaxys Levels" "Levels 39-40" "Chose utility upgrade."
+				log Levels "Novaxys" "Levels 39-40: Chose utility upgrade."
 			`"Utilities... I think I have a few ideas, Captain," Rosalynd nods.`
 				goto next
 

--- a/data/novaxys/levels41-80.txt
+++ b/data/novaxys/levels41-80.txt
@@ -191,25 +191,25 @@ mission "Novaxys Level 41-42"
 			label durability
 			action
 				outfit "Novaxys Durability III" 1
-				log "Novaxys Levels" "Levels 41-42" "Chose durability upgrade."
+				log Levels "Novaxys" "Levels 41-42: Chose durability upgrade."
 			`"Okay, Captain," Rosalynd replies. "It would be nice to not get blown up."`
 				goto next
 			label support
 			action
 				outfit "Novaxys Support III" 1
-				log "Novaxys Levels" "Levels 41-42" "Chose support upgrade."
+				log Levels "Novaxys" "Levels 41-42: Chose support upgrade."
 			`"It doesn't hurt to carry extra equipment," Rosalynd agrees.`
 				goto next
 			label combat
 			action
 				outfit "Novaxys Combat III" 1
-				log "Novaxys Levels" "Levels 42-43" "Chose combat upgrade."
+				log Levels "Novaxys" "Levels 41-42: Chose combat upgrade."
 			`"I would like to be a stronger fighter," Rosalynd nods. "Okay, Captain."`
 				goto next
 			label utility
 			action
 				outfit "Novaxys Utility III" 1
-				log "Novaxys Levels" "Levels 42-43" "Chose utility upgrade."
+				log Levels "Novaxys" "Levels 41-42: Chose utility upgrade."
 			`"Utilities... I think I have a few ideas, Captain," Rosalynd nods.`
 				goto next
 
@@ -255,25 +255,25 @@ mission "Novaxys Level 43-44"
 			label durability
 			action
 				outfit "Novaxys Durability III" 1
-				log "Novaxys Levels" "Levels 43-44" "Chose durability upgrade."
+				log Levels "Novaxys" "Levels 43-44: Chose durability upgrade."
 			`"Okay, Captain," Rosalynd replies. "It would be nice to not get blown up."`
 				goto next
 			label support
 			action
 				outfit "Novaxys Support III" 1
-				log "Novaxys Levels" "Levels 43-44" "Chose support upgrade."
+				log Levels "Novaxys" "Levels 43-44: Chose support upgrade."
 			`"It doesn't hurt to carry extra equipment," Rosalynd agrees.`
 				goto next
 			label combat
 			action
 				outfit "Novaxys Combat III" 1
-				log "Novaxys Levels" "Levels 43-44" "Chose combat upgrade."
+				log Levels "Novaxys" "Levels 43-44: Chose combat upgrade."
 			`"I would like to be a stronger fighter," Rosalynd nods. "Okay, Captain."`
 				goto next
 			label utility
 			action
 				outfit "Novaxys Utility III" 1
-				log "Novaxys Levels" "Levels 43-44" "Chose utility upgrade."
+				log Levels "Novaxys" "Levels 43-44: Chose utility upgrade."
 			`"Utilities... I think I have a few ideas, Captain," Rosalynd nods.`
 				goto next
 
@@ -319,25 +319,25 @@ mission "Novaxys Level 45-46"
 			label durability
 			action
 				outfit "Novaxys Durability III" 1
-				log "Novaxys Levels" "Levels 45-46" "Chose durability upgrade."
+				log Levels "Novaxys" "Levels 45-46: Chose durability upgrade."
 			`"Okay, Captain," Rosalynd replies. "It would be nice to not get blown up."`
 				goto next
 			label support
 			action
 				outfit "Novaxys Support III" 1
-				log "Novaxys Levels" "Levels 45-46" "Chose support upgrade."
+				log Levels "Novaxys" "Levels 45-46: Chose support upgrade."
 			`"It doesn't hurt to carry extra equipment," Rosalynd agrees.`
 				goto next
 			label combat
 			action
 				outfit "Novaxys Combat III" 1
-				log "Novaxys Levels" "Levels 45-46" "Chose combat upgrade."
+				log Levels "Novaxys" "Levels 45-46: Chose combat upgrade."
 			`"I would like to be a stronger fighter," Rosalynd nods. "Okay, Captain."`
 				goto next
 			label utility
 			action
 				outfit "Novaxys Utility III" 1
-				log "Novaxys Levels" "Levels 45-46" "Chose utility upgrade."
+				log Levels "Novaxys" "Levels 45-46: Chose utility upgrade."
 			`"Utilities... I think I have a few ideas, Captain," Rosalynd nods.`
 				goto next
 
@@ -383,25 +383,25 @@ mission "Novaxys Level 47-48"
 			label durability
 			action
 				outfit "Novaxys Durability III" 1
-				log "Novaxys Levels" "Levels 47-48" "Chose durability upgrade."
+				log Levels "Novaxys" "Levels 47-48: Chose durability upgrade."
 			`"Okay, Captain," Rosalynd replies. "It would be nice to not get blown up."`
 				goto next
 			label support
 			action
 				outfit "Novaxys Support III" 1
-				log "Novaxys Levels" "Levels 47-48" "Chose support upgrade."
+				log Levels "Novaxys" "Levels 47-48: Chose support upgrade."
 			`"It doesn't hurt to carry extra equipment," Rosalynd agrees.`
 				goto next
 			label combat
 			action
 				outfit "Novaxys Combat III" 1
-				log "Novaxys Levels" "Levels 47-48" "Chose combat upgrade."
+				log Levels "Novaxys" "Levels 47-48: Chose combat upgrade."
 			`"I would like to be a stronger fighter," Rosalynd nods. "Okay, Captain."`
 				goto next
 			label utility
 			action
 				outfit "Novaxys Utility III" 1
-				log "Novaxys Levels" "Levels 47-48" "Chose utility upgrade."
+				log Levels "Novaxys" "Levels 47-48: Chose utility upgrade."
 			`"Utilities... I think I have a few ideas, Captain," Rosalynd nods.`
 				goto next
 
@@ -447,25 +447,25 @@ mission "Novaxys Level 49-50"
 			label durability
 			action
 				outfit "Novaxys Durability III" 1
-				log "Novaxys Levels" "Levels 49-50" "Chose durability upgrade."
+				log Levels "Novaxys" "Levels 49-50: Chose durability upgrade."
 			`"Okay, Captain," Rosalynd replies. "It would be nice to not get blown up."`
 				goto next
 			label support
 			action
 				outfit "Novaxys Support III" 1
-				log "Novaxys Levels" "Levels 49-50" "Chose support upgrade."
+				log Levels "Novaxys" "Levels 49-50: Chose support upgrade."
 			`"It doesn't hurt to carry extra equipment," Rosalynd agrees.`
 				goto next
 			label combat
 			action
 				outfit "Novaxys Combat III" 1
-				log "Novaxys Levels" "Levels 49-50" "Chose combat upgrade."
+				log Levels "Novaxys" "Levels 49-50: Chose combat upgrade."
 			`"I would like to be a stronger fighter," Rosalynd nods. "Okay, Captain."`
 				goto next
 			label utility
 			action
 				outfit "Novaxys Utility III" 1
-				log "Novaxys Levels" "Levels 49-50" "Chose utility upgrade."
+				log Levels "Novaxys" "Levels 49-50: Chose utility upgrade."
 			`"Utilities... I think I have a few ideas, Captain," Rosalynd nods.`
 				goto next
 
@@ -511,25 +511,25 @@ mission "Novaxys Level 51-52"
 			label durability
 			action
 				outfit "Novaxys Durability III" 1
-				log "Novaxys Levels" "Levels 51-52" "Chose durability upgrade."
+				log Levels "Novaxys" "Levels 51-52: Chose durability upgrade."
 			`"Okay, Captain," Rosalynd replies. "It would be nice to not get blown up."`
 				goto next
 			label support
 			action
 				outfit "Novaxys Support III" 1
-				log "Novaxys Levels" "Levels 51-52" "Chose support upgrade."
+				log Levels "Novaxys" "Levels 51-52: Chose support upgrade."
 			`"It doesn't hurt to carry extra equipment," Rosalynd agrees.`
 				goto next
 			label combat
 			action
 				outfit "Novaxys Combat III" 1
-				log "Novaxys Levels" "Levels 52-53" "Chose combat upgrade."
+				log Levels "Novaxys" "Levels 51-52: Chose combat upgrade."
 			`"I would like to be a stronger fighter," Rosalynd nods. "Okay, Captain."`
 				goto next
 			label utility
 			action
 				outfit "Novaxys Utility III" 1
-				log "Novaxys Levels" "Levels 52-53" "Chose utility upgrade."
+				log Levels "Novaxys" "Levels 51-52: Chose utility upgrade."
 			`"Utilities... I think I have a few ideas, Captain," Rosalynd nods.`
 				goto next
 
@@ -575,25 +575,25 @@ mission "Novaxys Level 53-54"
 			label durability
 			action
 				outfit "Novaxys Durability III" 1
-				log "Novaxys Levels" "Levels 53-54" "Chose durability upgrade."
+				log Levels "Novaxys" "Levels 53-54: Chose durability upgrade."
 			`"Okay, Captain," Rosalynd replies. "It would be nice to not get blown up."`
 				goto next
 			label support
 			action
 				outfit "Novaxys Support III" 1
-				log "Novaxys Levels" "Levels 53-54" "Chose support upgrade."
+				log Levels "Novaxys" "Levels 53-54: Chose support upgrade."
 			`"It doesn't hurt to carry extra equipment," Rosalynd agrees.`
 				goto next
 			label combat
 			action
 				outfit "Novaxys Combat III" 1
-				log "Novaxys Levels" "Levels 53-54" "Chose combat upgrade."
+				log Levels "Novaxys" "Levels 53-54: Chose combat upgrade."
 			`"I would like to be a stronger fighter," Rosalynd nods. "Okay, Captain."`
 				goto next
 			label utility
 			action
 				outfit "Novaxys Utility III" 1
-				log "Novaxys Levels" "Levels 53-54" "Chose utility upgrade."
+				log Levels "Novaxys" "Levels 53-54: Chose utility upgrade."
 			`"Utilities... I think I have a few ideas, Captain," Rosalynd nods.`
 				goto next
 
@@ -639,25 +639,25 @@ mission "Novaxys Level 55-56"
 			label durability
 			action
 				outfit "Novaxys Durability III" 1
-				log "Novaxys Levels" "Levels 55-56" "Chose durability upgrade."
+				log Levels "Novaxys" "Levels 55-56: Chose durability upgrade."
 			`"Okay, Captain," Rosalynd replies. "It would be nice to not get blown up."`
 				goto next
 			label support
 			action
 				outfit "Novaxys Support III" 1
-				log "Novaxys Levels" "Levels 55-56" "Chose support upgrade."
+				log Levels "Novaxys" "Levels 55-56: Chose support upgrade."
 			`"It doesn't hurt to carry extra equipment," Rosalynd agrees.`
 				goto next
 			label combat
 			action
 				outfit "Novaxys Combat III" 1
-				log "Novaxys Levels" "Levels 55-56" "Chose combat upgrade."
+				log Levels "Novaxys" "Levels 55-56: Chose combat upgrade."
 			`"I would like to be a stronger fighter," Rosalynd nods. "Okay, Captain."`
 				goto next
 			label utility
 			action
 				outfit "Novaxys Utility III" 1
-				log "Novaxys Levels" "Levels 55-56" "Chose utility upgrade."
+				log Levels "Novaxys" "Levels 55-56: Chose utility upgrade."
 			`"Utilities... I think I have a few ideas, Captain," Rosalynd nods.`
 				goto next
 
@@ -703,25 +703,25 @@ mission "Novaxys Level 57-58"
 			label durability
 			action
 				outfit "Novaxys Durability III" 1
-				log "Novaxys Levels" "Levels 57-58" "Chose durability upgrade."
+				log Levels "Novaxys" "Levels 57-58: Chose durability upgrade."
 			`"Okay, Captain," Rosalynd replies. "It would be nice to not get blown up."`
 				goto next
 			label support
 			action
 				outfit "Novaxys Support III" 1
-				log "Novaxys Levels" "Levels 57-58" "Chose support upgrade."
+				log Levels "Novaxys" "Levels 57-58: Chose support upgrade."
 			`"It doesn't hurt to carry extra equipment," Rosalynd agrees.`
 				goto next
 			label combat
 			action
 				outfit "Novaxys Combat III" 1
-				log "Novaxys Levels" "Levels 57-58" "Chose combat upgrade."
+				log Levels "Novaxys" "Levels 57-58: Chose combat upgrade."
 			`"I would like to be a stronger fighter," Rosalynd nods. "Okay, Captain."`
 				goto next
 			label utility
 			action
 				outfit "Novaxys Utility III" 1
-				log "Novaxys Levels" "Levels 57-58" "Chose utility upgrade."
+				log Levels "Novaxys" "Levels 57-58: Chose utility upgrade."
 			`"Utilities... I think I have a few ideas, Captain," Rosalynd nods.`
 				goto next
 
@@ -767,25 +767,25 @@ mission "Novaxys Level 59-60"
 			label durability
 			action
 				outfit "Novaxys Durability III" 1
-				log "Novaxys Levels" "Levels 59-60" "Chose durability upgrade."
+				log Levels "Novaxys" "Levels 59-60: Chose durability upgrade."
 			`"Okay, Captain," Rosalynd replies. "It would be nice to not get blown up."`
 				goto next
 			label support
 			action
 				outfit "Novaxys Support III" 1
-				log "Novaxys Levels" "Levels 59-60" "Chose support upgrade."
+				log Levels "Novaxys" "Levels 59-60: Chose support upgrade."
 			`"It doesn't hurt to carry extra equipment," Rosalynd agrees.`
 				goto next
 			label combat
 			action
 				outfit "Novaxys Combat III" 1
-				log "Novaxys Levels" "Levels 59-60" "Chose combat upgrade."
+				log Levels "Novaxys" "Levels 59-60: Chose combat upgrade."
 			`"I would like to be a stronger fighter," Rosalynd nods. "Okay, Captain."`
 				goto next
 			label utility
 			action
 				outfit "Novaxys Utility III" 1
-				log "Novaxys Levels" "Levels 59-60" "Chose utility upgrade."
+				log Levels "Novaxys" "Levels 59-60: Chose utility upgrade."
 			`"Utilities... I think I have a few ideas, Captain," Rosalynd nods.`
 				goto next
 
@@ -831,25 +831,25 @@ mission "Novaxys Level 61-62"
 			label durability
 			action
 				outfit "Novaxys Durability IV" 1
-				log "Novaxys Levels" "Levels 61-62" "Chose durability upgrade."
+				log Levels "Novaxys" "Levels 61-62: Chose durability upgrade."
 			`"Okay, Captain," Rosalynd replies. "It would be nice to not get blown up."`
 				goto next
 			label support
 			action
 				outfit "Novaxys Support IV" 1
-				log "Novaxys Levels" "Levels 61-62" "Chose support upgrade."
+				log Levels "Novaxys" "Levels 61-62: Chose support upgrade."
 			`"It doesn't hurt to carry extra equipment," Rosalynd agrees.`
 				goto next
 			label combat
 			action
 				outfit "Novaxys Combat IV" 1
-				log "Novaxys Levels" "Levels 62-63" "Chose combat upgrade."
+				log Levels "Novaxys" "Levels 61-62: Chose combat upgrade."
 			`"I would like to be a stronger fighter," Rosalynd nods. "Okay, Captain."`
 				goto next
 			label utility
 			action
 				outfit "Novaxys Utility IV" 1
-				log "Novaxys Levels" "Levels 62-63" "Chose utility upgrade."
+				log Levels "Novaxys" "Levels 61-62: Chose utility upgrade."
 			`"Utilities... I think I have a few ideas, Captain," Rosalynd nods.`
 				goto next
 
@@ -895,25 +895,25 @@ mission "Novaxys Level 63-64"
 			label durability
 			action
 				outfit "Novaxys Durability IV" 1
-				log "Novaxys Levels" "Levels 63-64" "Chose durability upgrade."
+				log Levels "Novaxys" "Levels 63-64: Chose durability upgrade."
 			`"Okay, Captain," Rosalynd replies. "It would be nice to not get blown up."`
 				goto next
 			label support
 			action
 				outfit "Novaxys Support IV" 1
-				log "Novaxys Levels" "Levels 63-64" "Chose support upgrade."
+				log Levels "Novaxys" "Levels 63-64: Chose support upgrade."
 			`"It doesn't hurt to carry extra equipment," Rosalynd agrees.`
 				goto next
 			label combat
 			action
 				outfit "Novaxys Combat IV" 1
-				log "Novaxys Levels" "Levels 63-64" "Chose combat upgrade."
+				log Levels "Novaxys" "Levels 63-64: Chose combat upgrade."
 			`"I would like to be a stronger fighter," Rosalynd nods. "Okay, Captain."`
 				goto next
 			label utility
 			action
 				outfit "Novaxys Utility IV" 1
-				log "Novaxys Levels" "Levels 63-64" "Chose utility upgrade."
+				log Levels "Novaxys" "Levels 63-64: Chose utility upgrade."
 			`"Utilities... I think I have a few ideas, Captain," Rosalynd nods.`
 				goto next
 
@@ -959,25 +959,25 @@ mission "Novaxys Level 65-66"
 			label durability
 			action
 				outfit "Novaxys Durability IV" 1
-				log "Novaxys Levels" "Levels 65-66" "Chose durability upgrade."
+				log Levels "Novaxys" "Levels 65-66: Chose durability upgrade."
 			`"Okay, Captain," Rosalynd replies. "It would be nice to not get blown up."`
 				goto next
 			label support
 			action
 				outfit "Novaxys Support IV" 1
-				log "Novaxys Levels" "Levels 65-66" "Chose support upgrade."
+				log Levels "Novaxys" "Levels 65-66: Chose support upgrade."
 			`"It doesn't hurt to carry extra equipment," Rosalynd agrees.`
 				goto next
 			label combat
 			action
 				outfit "Novaxys Combat IV" 1
-				log "Novaxys Levels" "Levels 65-66" "Chose combat upgrade."
+				log Levels "Novaxys" "Levels 65-66: Chose combat upgrade."
 			`"I would like to be a stronger fighter," Rosalynd nods. "Okay, Captain."`
 				goto next
 			label utility
 			action
 				outfit "Novaxys Utility IV" 1
-				log "Novaxys Levels" "Levels 65-66" "Chose utility upgrade."
+				log Levels "Novaxys" "Levels 65-66: Chose utility upgrade."
 			`"Utilities... I think I have a few ideas, Captain," Rosalynd nods.`
 				goto next
 
@@ -1023,25 +1023,25 @@ mission "Novaxys Level 67-68"
 			label durability
 			action
 				outfit "Novaxys Durability IV" 1
-				log "Novaxys Levels" "Levels 67-68" "Chose durability upgrade."
+				log Levels "Novaxys" "Levels 67-68: Chose durability upgrade."
 			`"Okay, Captain," Rosalynd replies. "It would be nice to not get blown up."`
 				goto next
 			label support
 			action
 				outfit "Novaxys Support IV" 1
-				log "Novaxys Levels" "Levels 67-68" "Chose support upgrade."
+				log Levels "Novaxys" "Levels 67-68: Chose support upgrade."
 			`"It doesn't hurt to carry extra equipment," Rosalynd agrees.`
 				goto next
 			label combat
 			action
 				outfit "Novaxys Combat IV" 1
-				log "Novaxys Levels" "Levels 67-68" "Chose combat upgrade."
+				log Levels "Novaxys" "Levels 67-68: Chose combat upgrade."
 			`"I would like to be a stronger fighter," Rosalynd nods. "Okay, Captain."`
 				goto next
 			label utility
 			action
 				outfit "Novaxys Utility IV" 1
-				log "Novaxys Levels" "Levels 67-68" "Chose utility upgrade."
+				log Levels "Novaxys" "Levels 67-68: Chose utility upgrade."
 			`"Utilities... I think I have a few ideas, Captain," Rosalynd nods.`
 				goto next
 
@@ -1087,25 +1087,25 @@ mission "Novaxys Level 69-70"
 			label durability
 			action
 				outfit "Novaxys Durability IV" 1
-				log "Novaxys Levels" "Levels 69-70" "Chose durability upgrade."
+				log Levels "Novaxys" "Levels 69-70: Chose durability upgrade."
 			`"Okay, Captain," Rosalynd replies. "It would be nice to not get blown up."`
 				goto next
 			label support
 			action
 				outfit "Novaxys Support IV" 1
-				log "Novaxys Levels" "Levels 69-70" "Chose support upgrade."
+				log Levels "Novaxys" "Levels 69-70: Chose support upgrade."
 			`"It doesn't hurt to carry extra equipment," Rosalynd agrees.`
 				goto next
 			label combat
 			action
 				outfit "Novaxys Combat IV" 1
-				log "Novaxys Levels" "Levels 69-70" "Chose combat upgrade."
+				log Levels "Novaxys" "Levels 69-70: Chose combat upgrade."
 			`"I would like to be a stronger fighter," Rosalynd nods. "Okay, Captain."`
 				goto next
 			label utility
 			action
 				outfit "Novaxys Utility IV" 1
-				log "Novaxys Levels" "Levels 69-70" "Chose utility upgrade."
+				log Levels "Novaxys" "Levels 69-70: Chose utility upgrade."
 			`"Utilities... I think I have a few ideas, Captain," Rosalynd nods.`
 				goto next
 
@@ -1151,25 +1151,25 @@ mission "Novaxys Level 71-72"
 			label durability
 			action
 				outfit "Novaxys Durability IV" 1
-				log "Novaxys Levels" "Levels 71-72" "Chose durability upgrade."
+				log Levels "Novaxys" "Levels 71-72: Chose durability upgrade."
 			`"Okay, Captain," Rosalynd replies. "It would be nice to not get blown up."`
 				goto next
 			label support
 			action
 				outfit "Novaxys Support IV" 1
-				log "Novaxys Levels" "Levels 71-72" "Chose support upgrade."
+				log Levels "Novaxys" "Levels 71-72: Chose support upgrade."
 			`"It doesn't hurt to carry extra equipment," Rosalynd agrees.`
 				goto next
 			label combat
 			action
 				outfit "Novaxys Combat IV" 1
-				log "Novaxys Levels" "Levels 72-73" "Chose combat upgrade."
+				log Levels "Novaxys" "Levels 71-72: Chose combat upgrade."
 			`"I would like to be a stronger fighter," Rosalynd nods. "Okay, Captain."`
 				goto next
 			label utility
 			action
 				outfit "Novaxys Utility IV" 1
-				log "Novaxys Levels" "Levels 72-73" "Chose utility upgrade."
+				log Levels "Novaxys" "Levels 71-72: Chose utility upgrade."
 			`"Utilities... I think I have a few ideas, Captain," Rosalynd nods.`
 				goto next
 
@@ -1215,25 +1215,25 @@ mission "Novaxys Level 73-74"
 			label durability
 			action
 				outfit "Novaxys Durability IV" 1
-				log "Novaxys Levels" "Levels 73-74" "Chose durability upgrade."
+				log Levels "Novaxys" "Levels 73-74: Chose durability upgrade."
 			`"Okay, Captain," Rosalynd replies. "It would be nice to not get blown up."`
 				goto next
 			label support
 			action
 				outfit "Novaxys Support IV" 1
-				log "Novaxys Levels" "Levels 73-74" "Chose support upgrade."
+				log Levels "Novaxys" "Levels 73-74: Chose support upgrade."
 			`"It doesn't hurt to carry extra equipment," Rosalynd agrees.`
 				goto next
 			label combat
 			action
 				outfit "Novaxys Combat IV" 1
-				log "Novaxys Levels" "Levels 73-74" "Chose combat upgrade."
+				log Levels "Novaxys" "Levels 73-74: Chose combat upgrade."
 			`"I would like to be a stronger fighter," Rosalynd nods. "Okay, Captain."`
 				goto next
 			label utility
 			action
 				outfit "Novaxys Utility IV" 1
-				log "Novaxys Levels" "Levels 73-74" "Chose utility upgrade."
+				log Levels "Novaxys" "Levels 73-74: Chose utility upgrade."
 			`"Utilities... I think I have a few ideas, Captain," Rosalynd nods.`
 				goto next
 
@@ -1279,25 +1279,25 @@ mission "Novaxys Level 75-76"
 			label durability
 			action
 				outfit "Novaxys Durability IV" 1
-				log "Novaxys Levels" "Levels 75-76" "Chose durability upgrade."
+				log Levels "Novaxys" "Levels 75-76: Chose durability upgrade."
 			`"Okay, Captain," Rosalynd replies. "It would be nice to not get blown up."`
 				goto next
 			label support
 			action
 				outfit "Novaxys Support IV" 1
-				log "Novaxys Levels" "Levels 75-76" "Chose support upgrade."
+				log Levels "Novaxys" "Levels 75-76: Chose support upgrade."
 			`"It doesn't hurt to carry extra equipment," Rosalynd agrees.`
 				goto next
 			label combat
 			action
 				outfit "Novaxys Combat IV" 1
-				log "Novaxys Levels" "Levels 75-76" "Chose combat upgrade."
+				log Levels "Novaxys" "Levels 75-76: Chose combat upgrade."
 			`"I would like to be a stronger fighter," Rosalynd nods. "Okay, Captain."`
 				goto next
 			label utility
 			action
 				outfit "Novaxys Utility IV" 1
-				log "Novaxys Levels" "Levels 75-76" "Chose utility upgrade."
+				log Levels "Novaxys" "Levels 75-76: Chose utility upgrade."
 			`"Utilities... I think I have a few ideas, Captain," Rosalynd nods.`
 				goto next
 
@@ -1343,25 +1343,25 @@ mission "Novaxys Level 77-78"
 			label durability
 			action
 				outfit "Novaxys Durability IV" 1
-				log "Novaxys Levels" "Levels 77-78" "Chose durability upgrade."
+				log Levels "Novaxys" "Levels 77-78: Chose durability upgrade."
 			`"Okay, Captain," Rosalynd replies. "It would be nice to not get blown up."`
 				goto next
 			label support
 			action
 				outfit "Novaxys Support IV" 1
-				log "Novaxys Levels" "Levels 77-78" "Chose support upgrade."
+				log Levels "Novaxys" "Levels 77-78: Chose support upgrade."
 			`"It doesn't hurt to carry extra equipment," Rosalynd agrees.`
 				goto next
 			label combat
 			action
 				outfit "Novaxys Combat IV" 1
-				log "Novaxys Levels" "Levels 77-78" "Chose combat upgrade."
+				log Levels "Novaxys" "Levels 77-78: Chose combat upgrade."
 			`"I would like to be a stronger fighter," Rosalynd nods. "Okay, Captain."`
 				goto next
 			label utility
 			action
 				outfit "Novaxys Utility IV" 1
-				log "Novaxys Levels" "Levels 77-78" "Chose utility upgrade."
+				log Levels "Novaxys" "Levels 77-78: Chose utility upgrade."
 			`"Utilities... I think I have a few ideas, Captain," Rosalynd nods.`
 				goto next
 

--- a/data/novaxys/perks list.txt
+++ b/data/novaxys/perks list.txt
@@ -13,8 +13,239 @@ mission "Novaxys Perks List"
 conversation "novaperkslist"
 	`Before you lies a large list of 'perks'; special upgrades that may alter how the ship handles in more drastic ways than simple level-up stat boosts. Be sure to read descriptions carefully!`
 	label hub
+	branch "available perks" "all perks"
+		"apoxys show all perks" == 0
+
+	label "available perks"
 	`	You have &[novaxys perks] perks left.`
 	choice
+		`	(Show all perks.)
+				action
+					"apoxys show all perks" = 1
+			goto "all perks"
+		`	(Core Restructure.)`
+			goto corerestructure
+		`	(Tough Shields.)`
+			to display
+				or
+					and
+						has "Novaxys Level 1-2: declined"
+						"outfit (flagship installed): Perk: Tough Shields" == 0
+					and
+						has "Novaxys Level 5-6: declined"
+						"outfit (flagship installed): Perk: Tough Shields" == 1
+					and
+						has "Novaxys Level 13-14: declined"
+						"outfit (flagship installed): Perk: Tough Shields" == 2
+					and
+						has "Novaxys Level 21-22: declined"
+						"outfit (flagship installed): Perk: Tough Shields" == 3
+					and
+						has "Novaxys Level 29-30: declined"
+						"outfit (flagship installed): Perk: Tough Shields" == 4
+					and
+						has "Novaxys Level 37-38: declined"
+						"outfit (flagship installed): Perk: Tough Shields" == 5
+					and
+						has "Novaxys Level 47-48: declined"
+						"outfit (flagship installed): Perk: Tough Shields" == 6
+					and
+						has "Novaxys Level 57-58: declined"
+						"outfit (flagship installed): Perk: Tough Shields" == 7
+					and
+						has "Novaxys Level 67-68: declined"
+						"outfit (flagship installed): Perk: Tough Shields" == 8
+					and
+						has "Novaxys Level 80 Choices: declined"
+						"outfit (flagship installed): Perk: Tough Shields" == 9
+			goto toughshields
+		`	(Thick Skin.)`
+			to display
+				or
+					and
+						has "Novaxys Level 1-2: declined"
+						"outfit (flagship installed): Perk: Thick Skin" == 0
+					and
+						has "Novaxys Level 5-6: declined"
+						"outfit (flagship installed): Perk: Thick Skin" == 1
+					and
+						has "Novaxys Level 13-14: declined"
+						"outfit (flagship installed): Perk: Thick Skin" == 2
+					and
+						has "Novaxys Level 21-22: declined"
+						"outfit (flagship installed): Perk: Thick Skin" == 3
+					and
+						has "Novaxys Level 29-30: declined"
+						"outfit (flagship installed): Perk: Thick Skin" == 4
+					and
+						has "Novaxys Level 37-38: declined"
+						"outfit (flagship installed): Perk: Thick Skin" == 5
+					and
+						has "Novaxys Level 47-48: declined"
+						"outfit (flagship installed): Perk: Thick Skin" == 6
+					and
+						has "Novaxys Level 57-58: declined"
+						"outfit (flagship installed): Perk: Thick Skin" == 7
+					and
+						has "Novaxys Level 67-68: declined"
+						"outfit (flagship installed): Perk: Thick Skin" == 8
+					and
+						has "Novaxys Level 80 Choices: declined"
+						"outfit (flagship installed): Perk: Thick Skin" == 9
+			goto thickskin
+		`	(Lighten Up.)`
+			goto lightenup
+			to display
+				or
+					and
+						has "Novaxys Level 7-8: declined"
+						"outfit (flagship installed): Perk: Lighten Up" == 0
+					and
+						has "Novaxys Level 19-20: declined"
+						"outfit (flagship installed): Perk: Lighten Up" == 1
+					and
+						has "Novaxys Level 35-36: declined"
+						"outfit (flagship installed): Perk: Lighten Up" == 2
+		`	(Unstoppable.)`
+				or
+					and
+						has "Novaxys Level 3-4: declined"
+						"outfit (flagship installed): Perk: Unstoppable" == 0
+					and
+						has "Novaxys Level 11-12: declined"
+						"outfit (flagship installed): Perk: Unstoppable" == 1
+					and
+						has "Novaxys Level 23-24: declined"
+						"outfit (flagship installed): Perk: Unstoppable" == 2
+					and
+						has "Novaxys Level 39-40: declined"
+						"outfit (flagship installed): Perk: Unstoppable" == 3
+					and
+						has "Novaxys Level 55-56: declined"
+						"outfit (flagship installed): Perk: Unstoppable" == 4
+					and
+						has "Novaxys Level 73-74: declined"
+						"outfit (flagship installed): Perk: Unstoppable" == 5
+			goto unstoppable
+		`	(Pack Mule.)`
+			to display
+				or
+					and
+						has "Novaxys Level 3-4: declined"
+						"outfit (flagship installed): Perk: Pack Mule" == 0
+					and
+						has "Novaxys Level 15-16: declined"
+						"outfit (flagship installed): Perk: Pack Mule" == 1
+					and
+						has "Novaxys Level 27-28: declined"
+						"outfit (flagship installed): Perk: Pack Mule" == 2
+					and
+						has "Novaxys Level 41-42: declined"
+						"outfit (flagship installed): Perk: Pack Mule" == 3
+					and
+						has "Novaxys Level 57-58: declined"
+						"outfit (flagship installed): Perk: Pack Mule" == 4
+			goto packmule
+		`	(Fuel Reserves.)`
+			to display
+				or
+					and
+						has "Novaxys Level 5-6: declined"
+						"outfit (flagship installed): Perk: Fuel Reserves" == 0
+					and
+						has "Novaxys Level 9-10: declined"
+						"outfit (flagship installed): Perk: Fuel Reserves" == 1
+					and
+						has "Novaxys Level 17-18: declined"
+						"outfit (flagship installed): Perk: Fuel Reserves" == 2
+					and
+						has "Novaxys Level 25-26: declined"
+						"outfit (flagship installed): Perk: Fuel Reserves" == 3
+					and
+						has "Novaxys Level 33-34: declined"
+						"outfit (flagship installed): Perk: Fuel Reserves" == 4
+			goto fuelreserves
+		`	(Thermophile.)`
+			to display
+				or
+					and
+						has "Novaxys Level 7-8: declined"
+						"outfit (flagship installed): Perk: Thermophile" == 0
+					and
+						has "Novaxys Level 23-24: declined"
+						"outfit (flagship installed): Perk: Thermophile" == 1
+					and
+						has "Novaxys Level 51-52: declined"
+						"outfit (flagship installed): Perk: Thermophile" == 2
+			goto thermophile
+		`	(Controlled Burn.)`
+			to display
+				or
+					and
+						has "Novaxys Level 15-16: declined"
+						"outfit (flagship installed): Perk: Controlled Burn" == 0
+					and
+						has "Novaxys Level 27-28: declined"
+						"outfit (flagship installed): Perk: Controlled Burn" == 1
+					and
+						has "Novaxys Level 39-40: declined"
+						"outfit (flagship installed): Perk: Controlled Burn" == 2
+			goto controlledburn
+		`	(Pyromaniac.)`
+			to display
+				or
+					and
+						has "Novaxys Level 17-18: declined"
+						"outfit (flagship installed): Perk: Pyromaniac" == 0
+					and
+						has "Novaxys Level 31-32: declined"
+						"outfit (flagship installed): Perk: Pyromaniac" == 1
+					and
+						has "Novaxys Level 45-46: declined"
+						"outfit (flagship installed): Perk: Pyromaniac" == 2
+			goto pyromaniac
+		`	(Tinder.)`
+			to display
+				or
+					and
+						has "Novaxys Level 19-20: declined"
+						"outfit (flagship installed): Perk: Tinder" == 0
+					and
+						has "Novaxys Level 35-36: declined"
+						"outfit (flagship installed): Perk: Tinder" == 1
+					and
+						has "Novaxys Level 51-52: declined"
+						"outfit (flagship installed): Perk: Tinder" == 2
+			goto tinder
+		`	(Burning Rush.)`
+			to display
+				or
+					and
+						has "Novaxys Level 9-10: declined"
+						"outfit (flagship installed): Perk: Burning Rush" == 0
+					and
+						has "Novaxys Level 21-22: declined"
+						"outfit (flagship installed): Perk: Burning Rush" == 1
+					and
+						has "Novaxys Level 33-34: declined"
+						"outfit (flagship installed): Perk: Burning Rush" == 2
+					and
+						has "Novaxys Level 45-46: declined"
+						"outfit (flagship installed): Perk: Burning Rush" == 3
+					and
+						has "Novaxys Level 59-60: declined"
+						"outfit (flagship installed): Perk: Burning Rush" == 4
+			goto burningrush
+		`	(Not now.)`
+			defer
+
+	label "all perks"
+	`	You have &[novaxys perks] perks left.`
+	choice
+		`	(Show available perks only.)
+				action
+					"apoxys show all perks" = 0
+			goto "available perks"
 		`	(Core Restructure.)`
 			goto corerestructure
 		`	(Tough Shields.)`

--- a/data/novaxys/perks list.txt
+++ b/data/novaxys/perks list.txt
@@ -340,7 +340,7 @@ conversation "novaperkslist"
 	action
 		"apoxys spec points" += 1
 		outfit "Fortitude" -1
-	`Fortitude increased by 1 (now &[outfit (flagship installed): Fortitude]).`
+	`Fortitude decreased by 1 (now &[outfit (flagship installed): Fortitude]).`
 		goto fortitude
 
 	label force
@@ -366,7 +366,7 @@ conversation "novaperkslist"
 	action
 		"apoxys spec points" += 1
 		outfit "Force" -1
-	`Force increased by 1 (now &[outfit (flagship installed): Force]).`
+	`Force decreased by 1 (now &[outfit (flagship installed): Force]).`
 		goto force
 
 	label focus
@@ -392,7 +392,7 @@ conversation "novaperkslist"
 	action
 		"apoxys spec points" += 1
 		outfit "Focus" -1
-	`Focus increased by 1 (now &[outfit (flagship installed): Focus]).`
+	`Focus decreased by 1 (now &[outfit (flagship installed): Focus]).`
 		goto focus
 
 	label flightiness
@@ -418,7 +418,7 @@ conversation "novaperkslist"
 	action
 		"apoxys spec points" += 1
 		outfit "Flightiness" -1
-	`Flightiness increased by 1 (now &[outfit (flagship installed): Flightiness]).`
+	`Flightiness decreased by 1 (now &[outfit (flagship installed): Flightiness]).`
 		goto flightiness
 
 	label friendliness
@@ -444,7 +444,7 @@ conversation "novaperkslist"
 	action
 		"apoxys spec points" += 1
 		outfit "Friendliness" -1
-	`Friendliness increased by 1 (now &[outfit (flagship installed): Friendliness]).`
+	`Friendliness decreased by 1 (now &[outfit (flagship installed): Friendliness]).`
 		goto friendliness
 
 	label toughshields

--- a/data/novaxys/perks list.txt
+++ b/data/novaxys/perks list.txt
@@ -107,6 +107,7 @@ conversation "novaperkslist"
 						has "Novaxys Level 35-36: declined"
 						"outfit (flagship installed): Perk: Lighten Up" == 2
 		`	(Unstoppable.)`
+			to display
 				or
 					and
 						has "Novaxys Level 3-4: declined"

--- a/data/patch Free Worlds campaign.txt
+++ b/data/patch Free Worlds campaign.txt
@@ -1,0 +1,45 @@
+mission "FW Pug 2C: Apoxys Drive"
+	landing
+	name "Investigate the Pug"
+	description "Travel to the Deneb system to investigate the Pug; if possible, make contact with them and determine what their goals and desires are."
+	source Hephaestus
+	destination Pugglemug
+	clearance
+	to offer
+		has "FW Pug 2B: done"
+		not "fw given jump drive"
+		or
+			has "outfit (flagship installed): Key Drive"
+			has "outfit (flagship installed): Reserve Drive"
+			has "outfit (flagship installed): Skip Drive"
+	passengers 1
+	on fail
+		dialog `You have failed an essential Free Worlds mission. If you want to complete the story line, revert to the autosave or another earlier snapshot of the game.`
+	
+	on offer
+		conversation
+			`You are directed to land in a hangar some distance away from the spaceport, in a cluster of buildings owned by Syndicated Systems. A team of engineers meets you and asks if they can look over your ship; a few minutes later, one of them says in surprise, "You've already got a jump drive! How did you manage that?" Since you don't need their equipment, they urge you to head directly for Pug space and continue your mission.`
+				accept
+	
+	on accept
+		set "fw given jump drive"
+		set "already had jump drive"
+	on visit
+		dialog `You land on <planet>, but realize that your escort carrying Alondo hasn't entered the system yet. Better depart and wait for it to arrive.`
+	on complete
+		set "FW Pug 2C: done"
+
+mission "FW Pug Jump Drive Check"
+	landing
+	to offer
+		has "fw given jump drive"
+		not "outfit (all): Jump Drive"
+		not "outfit (all): Key Drive"
+		not "outfit (all): Reserve Drive"
+		not "outfit (all): Skip Drive"
+		not "event: reconnected delta capricorni"
+	on offer
+		conversation
+			`Somehow, you've misplaced or lost the jump drive needed to continue the Free Worlds story! If you are unable to find your jump drive, you should revert to the autosave or another earlier snapshot of the game.`
+				decline
+

--- a/data/start.txt
+++ b/data/start.txt
@@ -182,7 +182,7 @@ conversation "toa intro"
 	action
 		"apoxys spec points" += 1
 		outfit "Fortitude" -1
-	`Fortitude increased by 1 (now &[outfit (flagship installed): Fortitude]).`
+	`Fortitude decreased by 1 (now &[outfit (flagship installed): Fortitude]).`
 		goto fortitude
 
 	label force
@@ -208,7 +208,7 @@ conversation "toa intro"
 	action
 		"apoxys spec points" += 1
 		outfit "Force" -1
-	`Force increased by 1 (now &[outfit (flagship installed): Force]).`
+	`Force decreased by 1 (now &[outfit (flagship installed): Force]).`
 		goto force
 
 	label focus
@@ -234,17 +234,17 @@ conversation "toa intro"
 	action
 		"apoxys spec points" += 1
 		outfit "Focus" -1
-	`Focus increased by 1 (now &[outfit (flagship installed): Focus]).`
+	`Focus decreased by 1 (now &[outfit (flagship installed): Focus]).`
 		goto focus
 
 	label flightiness
 	`Flightiness refers to your agility. A high flightiness will allow you to move and regenerate faster.`
 	choice
-		`	(Increase Focus by 1.)`
+		`	(Increase Flightiness by 1.)`
 				to display
 					"apoxys spec points" >= 1
 			goto addflightiness
-		`	(Decrease Focus by 1.)`
+		`	(Decrease Flightiness by 1.)`
 				to display
 					"outfit (flagship installed): Flightiness" >= 2
 			goto subflightiness
@@ -254,13 +254,13 @@ conversation "toa intro"
 	action
 		"apoxys spec points" -= 1
 		outfit "Flightiness" 1
-	`Focus increased by 1 (now &[outfit (flagship installed): Flightiness]).`
+	`Flightiness increased by 1 (now &[outfit (flagship installed): Flightiness]).`
 		goto flightiness
 	label subflightiness
 	action
 		"apoxys spec points" += 1
 		outfit "Flightiness" -1
-	`Focus increased by 1 (now &[outfit (flagship installed): Flightiness]).`
+	`Flightiness decreased by 1 (now &[outfit (flagship installed): Flightiness]).`
 		goto flightiness
 
 	label friendliness
@@ -286,7 +286,7 @@ conversation "toa intro"
 	action
 		"apoxys spec points" += 1
 		outfit "Friendliness" -1
-	`Friendliness increased by 1 (now &[outfit (flagship installed): Friendliness]).`
+	`Friendliness decreased by 1 (now &[outfit (flagship installed): Friendliness]).`
 		goto friendliness
 
 


### PR DESCRIPTION
Change logbook entries for level ups to be all in one category, with the type of level up (Apoxys, Merchant, or Novaxys) as the header, instead of having a separate category for each type of level up and the level as the header.

This should keep the levels in chronological order within each category, where before the logbook would sort them alphabetically (e.g. "Level 10" before "Level 2").